### PR TITLE
feat: add MCP stdio server (adapty mcp command)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
     "url": "https://github.com/adaptyteam/adapty-cli/issues"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@oclif/core": "^4",
     "@oclif/plugin-help": "^6",
-    "open": "^11.0.0"
+    "open": "^11.0.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/compat": "^1",
@@ -79,6 +81,9 @@
       },
       "placements": {
         "description": "Manage placements"
+      },
+      "mcp": {
+        "description": "MCP server"
       }
     }
   },

--- a/src/commands/mcp/index.ts
+++ b/src/commands/mcp/index.ts
@@ -1,0 +1,20 @@
+import {Command} from '@oclif/core'
+import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js'
+import {StdioServerTransport} from '@modelcontextprotocol/sdk/server/stdio.js'
+
+import {registerAllTools} from '../../lib/mcp/server.js'
+
+export default class Mcp extends Command {
+  static description = 'Start an MCP server over stdio'
+  static examples = ['<%= config.bin %> mcp']
+
+  async run(): Promise<void> {
+    const server = new McpServer({name: 'adapty-mcp', version: this.config.version})
+    registerAllTools(server, this.config)
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    process.stderr.write('Adapty MCP server running on stdio\n')
+    // Keep alive — the stdio transport holds the connection
+    await new Promise<void>(() => {})
+  }
+}

--- a/src/commands/mcp/index.ts
+++ b/src/commands/mcp/index.ts
@@ -12,9 +12,13 @@ export default class Mcp extends Command {
     const server = new McpServer({name: 'adapty-mcp', version: this.config.version})
     registerAllTools(server, this.config)
     const transport = new StdioServerTransport()
-    await server.connect(transport)
     process.stderr.write('Adapty MCP server running on stdio\n')
-    // Keep alive — the stdio transport holds the connection
-    await new Promise<void>(() => {})
+    await server.connect(transport)
+    // Keep alive until the MCP client disconnects or the process is signalled.
+    await new Promise<void>((resolve) => {
+      process.stdin.once('close', () => server.close().finally(resolve))
+      process.once('SIGTERM', () => server.close().finally(resolve))
+      process.once('SIGINT', () => server.close().finally(resolve))
+    })
   }
 }

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -1,0 +1,18 @@
+import type {Config} from '@oclif/core'
+import type {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js'
+
+import {registerAccessLevelsTools} from './tools/access-levels.js'
+import {registerAppsTools} from './tools/apps.js'
+import {registerAuthTools} from './tools/auth.js'
+import {registerPaywallsTools} from './tools/paywalls.js'
+import {registerPlacementsTools} from './tools/placements.js'
+import {registerProductsTools} from './tools/products.js'
+
+export function registerAllTools(server: McpServer, config: Config): void {
+  registerAuthTools(server, config)
+  registerAppsTools(server, config)
+  registerProductsTools(server, config)
+  registerPaywallsTools(server, config)
+  registerPlacementsTools(server, config)
+  registerAccessLevelsTools(server, config)
+}

--- a/src/lib/mcp/tools/access-levels.ts
+++ b/src/lib/mcp/tools/access-levels.ts
@@ -1,0 +1,79 @@
+import type {Config} from '@oclif/core'
+import type {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js'
+import {z} from 'zod'
+
+import {createAuthenticatedClient} from '../../client-from-config.js'
+import {fail, ok, paginationParams} from '../utils.js'
+
+export function registerAccessLevelsTools(server: McpServer, config: Config): void {
+  server.tool(
+    'adapty_access_levels_list',
+    'List all access levels for an Adapty app.',
+    {
+      app_id: z.string().uuid().describe('App ID (UUID)'),
+      page: z.number().int().min(1).optional().describe('Page number (default: 1)'),
+      page_size: z.number().int().min(1).max(100).optional().describe('Items per page (default: 20, max: 100)'),
+    },
+    async ({app_id, page, page_size}) => {
+      try {
+        const client = await createAuthenticatedClient(config)
+        return ok(await client.get(`/apps/${app_id}/access-levels`, paginationParams(page, page_size)))
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  )
+
+  server.tool(
+    'adapty_access_levels_get',
+    'Get details for a specific access level.',
+    {
+      app_id: z.string().uuid().describe('App ID (UUID)'),
+      access_level_id: z.string().uuid().describe('Access level ID (UUID)'),
+    },
+    async ({app_id, access_level_id}) => {
+      try {
+        const client = await createAuthenticatedClient(config)
+        return ok(await client.get(`/apps/${app_id}/access-levels/${access_level_id}`))
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  )
+
+  server.tool(
+    'adapty_access_levels_create',
+    'Create a custom access level. IMPORTANT: sdk_id is IMMUTABLE after creation and cannot be changed.',
+    {
+      app_id: z.string().uuid().describe('App ID (UUID)'),
+      sdk_id: z.string().min(1).describe('SDK identifier used in app code (e.g. "premium") — IMMUTABLE after creation'),
+      title: z.string().min(1).describe('Access level title'),
+    },
+    async ({app_id, sdk_id, title}) => {
+      try {
+        const client = await createAuthenticatedClient(config)
+        return ok(await client.post(`/apps/${app_id}/access-levels`, {sdk_id, title}))
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  )
+
+  server.tool(
+    'adapty_access_levels_update',
+    'Update an access level title. Note: sdk_id cannot be changed after creation.',
+    {
+      app_id: z.string().uuid().describe('App ID (UUID)'),
+      access_level_id: z.string().uuid().describe('Access level ID (UUID)'),
+      title: z.string().min(1).describe('New access level title'),
+    },
+    async ({app_id, access_level_id, title}) => {
+      try {
+        const client = await createAuthenticatedClient(config)
+        return ok(await client.put(`/apps/${app_id}/access-levels/${access_level_id}`, {title}))
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  )
+}

--- a/src/lib/mcp/tools/apps.ts
+++ b/src/lib/mcp/tools/apps.ts
@@ -1,0 +1,92 @@
+import type {Config} from '@oclif/core'
+import type {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js'
+import {z} from 'zod'
+
+import {createAuthenticatedClient} from '../../client-from-config.js'
+import {fail, ok, paginationParams} from '../utils.js'
+
+export function registerAppsTools(server: McpServer, config: Config): void {
+  server.tool(
+    'adapty_apps_list',
+    'List all Adapty apps. Returns paginated results.',
+    {
+      page: z.number().int().min(1).optional().describe('Page number (default: 1)'),
+      page_size: z.number().int().min(1).max(100).optional().describe('Items per page (default: 20, max: 100)'),
+    },
+    async ({page, page_size}) => {
+      try {
+        const client = await createAuthenticatedClient(config)
+        return ok(await client.get('/apps', paginationParams(page, page_size)))
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  )
+
+  server.tool(
+    'adapty_apps_get',
+    'Get details for a specific Adapty app.',
+    {app_id: z.string().uuid().describe('App ID (UUID)')},
+    async ({app_id}) => {
+      try {
+        const client = await createAuthenticatedClient(config)
+        return ok(await client.get(`/apps/${app_id}`))
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  )
+
+  server.tool(
+    'adapty_apps_create',
+    'Create a new Adapty app. apple_bundle_id required when ios in platforms; google_bundle_id required when android in platforms.',
+    {
+      title: z.string().min(1).describe('App title'),
+      platforms: z.array(z.enum(['ios', 'android'])).min(1).describe('Target platforms'),
+      apple_bundle_id: z.string().optional().describe('Apple bundle ID (required if platforms includes ios)'),
+      google_bundle_id: z.string().optional().describe('Google bundle ID (required if platforms includes android)'),
+    },
+    async ({title, platforms, apple_bundle_id, google_bundle_id}) => {
+      try {
+        if (platforms.includes('ios') && !apple_bundle_id)
+          return fail('apple_bundle_id is required when platforms includes ios')
+        if (platforms.includes('android') && !google_bundle_id)
+          return fail('google_bundle_id is required when platforms includes android')
+
+        const client = await createAuthenticatedClient(config)
+        const body: Record<string, unknown> = {title, platforms}
+        if (apple_bundle_id) body.apple_bundle_id = apple_bundle_id
+        if (google_bundle_id) body.google_bundle_id = google_bundle_id
+        return ok(await client.post('/apps', body))
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  )
+
+  server.tool(
+    'adapty_apps_update',
+    'Update an existing Adapty app. At least one of title, apple_bundle_id, or google_bundle_id must be provided.',
+    {
+      app_id: z.string().uuid().describe('App ID (UUID)'),
+      title: z.string().optional().describe('New app title'),
+      apple_bundle_id: z.string().optional().describe('New Apple bundle ID'),
+      google_bundle_id: z.string().optional().describe('New Google bundle ID'),
+    },
+    async ({app_id, title, apple_bundle_id, google_bundle_id}) => {
+      try {
+        if (!title && !apple_bundle_id && !google_bundle_id)
+          return fail('At least one of title, apple_bundle_id, or google_bundle_id is required')
+
+        const client = await createAuthenticatedClient(config)
+        const body: Record<string, unknown> = {}
+        if (title) body.title = title
+        if (apple_bundle_id) body.apple_bundle_id = apple_bundle_id
+        if (google_bundle_id) body.google_bundle_id = google_bundle_id
+        return ok(await client.put(`/apps/${app_id}`, body))
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  )
+}

--- a/src/lib/mcp/tools/auth.ts
+++ b/src/lib/mcp/tools/auth.ts
@@ -1,0 +1,32 @@
+import type {Config} from '@oclif/core'
+import type {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js'
+
+import {createAuthenticatedClient} from '../../client-from-config.js'
+import {readConfig} from '../../config.js'
+import {fail, ok} from '../utils.js'
+
+export function registerAuthTools(server: McpServer, config: Config): void {
+  server.tool('adapty_auth_whoami', 'Show current user info by verifying the token against the Adapty API.', {}, async () => {
+    try {
+      const client = await createAuthenticatedClient(config)
+      return ok(await client.get('/me'))
+    } catch (err) {
+      return fail(err)
+    }
+  })
+
+  server.tool('adapty_auth_status', 'Check local authentication state without making a network request.', {}, async () => {
+    try {
+      const cfg = await readConfig(config.configDir)
+      if (!cfg.access_token || !cfg.user) return ok({authenticated: false})
+      return ok({
+        authenticated: true,
+        email: cfg.user.email,
+        token_prefix: cfg.access_token.slice(0, 8),
+        config_path: `${config.configDir}/config.json`,
+      })
+    } catch (err) {
+      return fail(err)
+    }
+  })
+}

--- a/src/lib/mcp/tools/auth.ts
+++ b/src/lib/mcp/tools/auth.ts
@@ -19,12 +19,7 @@ export function registerAuthTools(server: McpServer, config: Config): void {
     try {
       const cfg = await readConfig(config.configDir)
       if (!cfg.access_token || !cfg.user) return ok({authenticated: false})
-      return ok({
-        authenticated: true,
-        email: cfg.user.email,
-        token_prefix: cfg.access_token.slice(0, 8),
-        config_path: `${config.configDir}/config.json`,
-      })
+      return ok({authenticated: true, email: cfg.user.email})
     } catch (err) {
       return fail(err)
     }

--- a/src/lib/mcp/tools/paywalls.ts
+++ b/src/lib/mcp/tools/paywalls.ts
@@ -1,0 +1,80 @@
+import type {Config} from '@oclif/core'
+import type {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js'
+import {z} from 'zod'
+
+import {createAuthenticatedClient} from '../../client-from-config.js'
+import {fail, ok, paginationParams} from '../utils.js'
+
+export function registerPaywallsTools(server: McpServer, config: Config): void {
+  server.tool(
+    'adapty_paywalls_list',
+    'List all paywalls for an Adapty app.',
+    {
+      app_id: z.string().uuid().describe('App ID (UUID)'),
+      page: z.number().int().min(1).optional().describe('Page number (default: 1)'),
+      page_size: z.number().int().min(1).max(100).optional().describe('Items per page (default: 20, max: 100)'),
+    },
+    async ({app_id, page, page_size}) => {
+      try {
+        const client = await createAuthenticatedClient(config)
+        return ok(await client.get(`/apps/${app_id}/paywalls`, paginationParams(page, page_size)))
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  )
+
+  server.tool(
+    'adapty_paywalls_get',
+    'Get details for a specific paywall.',
+    {
+      app_id: z.string().uuid().describe('App ID (UUID)'),
+      paywall_id: z.string().uuid().describe('Paywall ID (UUID)'),
+    },
+    async ({app_id, paywall_id}) => {
+      try {
+        const client = await createAuthenticatedClient(config)
+        return ok(await client.get(`/apps/${app_id}/paywalls/${paywall_id}`))
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  )
+
+  server.tool(
+    'adapty_paywalls_create',
+    'Create a paywall with one or more products.',
+    {
+      app_id: z.string().uuid().describe('App ID (UUID)'),
+      title: z.string().min(1).describe('Paywall title'),
+      product_ids: z.array(z.string().uuid()).min(1).describe('Product IDs (UUIDs) to include in this paywall'),
+    },
+    async ({app_id, title, product_ids}) => {
+      try {
+        const client = await createAuthenticatedClient(config)
+        return ok(await client.post(`/apps/${app_id}/paywalls`, {title, product_ids}))
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  )
+
+  server.tool(
+    'adapty_paywalls_update',
+    'Update a paywall. WARNING: This replaces ALL fields — any product_ids not listed will be removed. Fetch the current paywall first if you only want to change the title.',
+    {
+      app_id: z.string().uuid().describe('App ID (UUID)'),
+      paywall_id: z.string().uuid().describe('Paywall ID (UUID)'),
+      title: z.string().min(1).describe('Paywall title'),
+      product_ids: z.array(z.string().uuid()).min(1).describe('Complete list of product IDs — replaces all existing products on this paywall'),
+    },
+    async ({app_id, paywall_id, title, product_ids}) => {
+      try {
+        const client = await createAuthenticatedClient(config)
+        return ok(await client.put(`/apps/${app_id}/paywalls/${paywall_id}`, {title, product_ids}))
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  )
+}

--- a/src/lib/mcp/tools/placements.ts
+++ b/src/lib/mcp/tools/placements.ts
@@ -1,0 +1,82 @@
+import type {Config} from '@oclif/core'
+import type {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js'
+import {z} from 'zod'
+
+import {createAuthenticatedClient} from '../../client-from-config.js'
+import {fail, ok, paginationParams} from '../utils.js'
+
+export function registerPlacementsTools(server: McpServer, config: Config): void {
+  server.tool(
+    'adapty_placements_list',
+    'List all placements for an Adapty app.',
+    {
+      app_id: z.string().uuid().describe('App ID (UUID)'),
+      page: z.number().int().min(1).optional().describe('Page number (default: 1)'),
+      page_size: z.number().int().min(1).max(100).optional().describe('Items per page (default: 20, max: 100)'),
+    },
+    async ({app_id, page, page_size}) => {
+      try {
+        const client = await createAuthenticatedClient(config)
+        return ok(await client.get(`/apps/${app_id}/placements`, paginationParams(page, page_size)))
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  )
+
+  server.tool(
+    'adapty_placements_get',
+    'Get details for a specific placement.',
+    {
+      app_id: z.string().uuid().describe('App ID (UUID)'),
+      placement_id: z.string().uuid().describe('Placement ID (UUID)'),
+    },
+    async ({app_id, placement_id}) => {
+      try {
+        const client = await createAuthenticatedClient(config)
+        return ok(await client.get(`/apps/${app_id}/placements/${placement_id}`))
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  )
+
+  server.tool(
+    'adapty_placements_create',
+    'Create a placement linked to a paywall. The developer_id is the string your app uses at runtime to fetch this placement.',
+    {
+      app_id: z.string().uuid().describe('App ID (UUID)'),
+      title: z.string().min(1).describe('Placement title'),
+      developer_id: z.string().min(1).describe('Developer ID used by the SDK to fetch this placement at runtime'),
+      paywall_id: z.string().uuid().describe('Paywall ID (UUID) to link to this placement'),
+    },
+    async ({app_id, title, developer_id, paywall_id}) => {
+      try {
+        const client = await createAuthenticatedClient(config)
+        return ok(await client.post(`/apps/${app_id}/placements`, {title, developer_id, paywall_id}))
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  )
+
+  server.tool(
+    'adapty_placements_update',
+    'Update a placement. WARNING: This replaces ALL fields — fetch the current placement first if you only want to change one field.',
+    {
+      app_id: z.string().uuid().describe('App ID (UUID)'),
+      placement_id: z.string().uuid().describe('Placement ID (UUID)'),
+      title: z.string().min(1).describe('Placement title'),
+      developer_id: z.string().min(1).describe('Developer ID used by the SDK at runtime'),
+      paywall_id: z.string().uuid().describe('Paywall ID (UUID) — replaces the existing linked paywall'),
+    },
+    async ({app_id, placement_id, title, developer_id, paywall_id}) => {
+      try {
+        const client = await createAuthenticatedClient(config)
+        return ok(await client.put(`/apps/${app_id}/placements/${placement_id}`, {title, developer_id, paywall_id}))
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  )
+}

--- a/src/lib/mcp/tools/placements.ts
+++ b/src/lib/mcp/tools/placements.ts
@@ -47,7 +47,7 @@ export function registerPlacementsTools(server: McpServer, config: Config): void
     {
       app_id: z.string().uuid().describe('App ID (UUID)'),
       title: z.string().min(1).describe('Placement title'),
-      developer_id: z.string().min(1).describe('Developer ID used by the SDK to fetch this placement at runtime'),
+      developer_id: z.string().min(1).describe('Developer ID used by the SDK to fetch this placement at runtime — must match the string literal in your app source code. IMMUTABLE after creation.'),
       paywall_id: z.string().uuid().describe('Paywall ID (UUID) to link to this placement'),
     },
     async ({app_id, title, developer_id, paywall_id}) => {

--- a/src/lib/mcp/tools/products.ts
+++ b/src/lib/mcp/tools/products.ts
@@ -1,0 +1,95 @@
+import type {Config} from '@oclif/core'
+import type {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js'
+import {z} from 'zod'
+
+import {createAuthenticatedClient} from '../../client-from-config.js'
+import {fail, ok, paginationParams} from '../utils.js'
+
+const PERIODS = ['weekly', 'monthly', 'two_months', 'trimonthly', 'semiannual', 'annual', 'lifetime'] as const
+
+export function registerProductsTools(server: McpServer, config: Config): void {
+  server.tool(
+    'adapty_products_list',
+    'List all products for an Adapty app.',
+    {
+      app_id: z.string().uuid().describe('App ID (UUID)'),
+      page: z.number().int().min(1).optional().describe('Page number (default: 1)'),
+      page_size: z.number().int().min(1).max(100).optional().describe('Items per page (default: 20, max: 100)'),
+    },
+    async ({app_id, page, page_size}) => {
+      try {
+        const client = await createAuthenticatedClient(config)
+        return ok(await client.get(`/apps/${app_id}/products`, paginationParams(page, page_size)))
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  )
+
+  server.tool(
+    'adapty_products_get',
+    'Get details for a specific product.',
+    {
+      app_id: z.string().uuid().describe('App ID (UUID)'),
+      product_id: z.string().uuid().describe('Product ID (UUID)'),
+    },
+    async ({app_id, product_id}) => {
+      try {
+        const client = await createAuthenticatedClient(config)
+        return ok(await client.get(`/apps/${app_id}/products/${product_id}`))
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  )
+
+  server.tool(
+    'adapty_products_create',
+    'Create a product. IMPORTANT: period, ios_product_id, android_product_id, and android_base_plan_id are IMMUTABLE after creation. At least one of ios_product_id or android_product_id is required. android_base_plan_id is required for Android non-lifetime subscriptions.',
+    {
+      app_id: z.string().uuid().describe('App ID (UUID)'),
+      title: z.string().min(1).describe('Product title'),
+      period: z.enum(PERIODS).describe('Subscription period — IMMUTABLE after creation'),
+      access_level_id: z.string().uuid().describe('Access level ID (UUID)'),
+      ios_product_id: z.string().optional().describe('iOS product ID — IMMUTABLE after creation. Required if android_product_id not provided.'),
+      android_product_id: z.string().optional().describe('Android product ID — IMMUTABLE after creation. Required if ios_product_id not provided.'),
+      android_base_plan_id: z.string().optional().describe('Android base plan ID — IMMUTABLE after creation. Required for Android non-lifetime subscriptions.'),
+    },
+    async ({app_id, title, period, access_level_id, ios_product_id, android_product_id, android_base_plan_id}) => {
+      try {
+        if (!ios_product_id && !android_product_id)
+          return fail('At least one of ios_product_id or android_product_id is required')
+        if (android_product_id && !android_base_plan_id && period !== 'lifetime')
+          return fail('android_base_plan_id is required with android_product_id for non-lifetime subscriptions')
+
+        const client = await createAuthenticatedClient(config)
+        const body: Record<string, unknown> = {title, period, access_level_id}
+        if (ios_product_id) body.ios_product_id = ios_product_id
+        if (android_product_id) body.android_product_id = android_product_id
+        if (android_base_plan_id) body.android_base_plan_id = android_base_plan_id
+        return ok(await client.post(`/apps/${app_id}/products`, body))
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  )
+
+  server.tool(
+    'adapty_products_update',
+    'Update a product title and access level. Note: period, ios_product_id, android_product_id, and android_base_plan_id cannot be changed after creation.',
+    {
+      app_id: z.string().uuid().describe('App ID (UUID)'),
+      product_id: z.string().uuid().describe('Product ID (UUID)'),
+      title: z.string().min(1).describe('Product title'),
+      access_level_id: z.string().uuid().describe('Access level ID (UUID)'),
+    },
+    async ({app_id, product_id, title, access_level_id}) => {
+      try {
+        const client = await createAuthenticatedClient(config)
+        return ok(await client.put(`/apps/${app_id}/products/${product_id}`, {title, access_level_id}))
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  )
+}

--- a/src/lib/mcp/tools/products.ts
+++ b/src/lib/mcp/tools/products.ts
@@ -76,7 +76,7 @@ export function registerProductsTools(server: McpServer, config: Config): void {
 
   server.tool(
     'adapty_products_update',
-    'Update a product title and access level. Note: period, ios_product_id, android_product_id, and android_base_plan_id cannot be changed after creation.',
+    'Update a product. WARNING: Both title and access_level_id are required — fetch the current product first if you only want to change one field. Note: period, ios_product_id, android_product_id, and android_base_plan_id cannot be changed after creation.',
     {
       app_id: z.string().uuid().describe('App ID (UUID)'),
       product_id: z.string().uuid().describe('Product ID (UUID)'),

--- a/src/lib/mcp/utils.ts
+++ b/src/lib/mcp/utils.ts
@@ -1,0 +1,17 @@
+import {ApiError, NetworkError} from '../errors.js'
+
+export function ok(data: unknown): {content: [{type: 'text'; text: string}]} {
+  return {content: [{type: 'text', text: JSON.stringify(data, null, 2)}]}
+}
+
+export function fail(err: unknown): {content: [{type: 'text'; text: string}]; isError: true} {
+  const text = err instanceof ApiError || err instanceof NetworkError ? err.toHuman() : String(err)
+  return {content: [{type: 'text', text}], isError: true}
+}
+
+export function paginationParams(page?: number, pageSize?: number): Record<string, string> {
+  const params: Record<string, string> = {}
+  if (page) params['page[number]'] = String(page)
+  if (pageSize) params['page[size]'] = String(pageSize)
+  return params
+}

--- a/src/lib/mcp/utils.ts
+++ b/src/lib/mcp/utils.ts
@@ -5,13 +5,20 @@ export function ok(data: unknown): {content: [{type: 'text'; text: string}]} {
 }
 
 export function fail(err: unknown): {content: [{type: 'text'; text: string}]; isError: true} {
-  const text = err instanceof ApiError || err instanceof NetworkError ? err.toHuman() : String(err)
+  let text: string
+  if (err instanceof ApiError || err instanceof NetworkError) {
+    text = err.toHuman()
+  } else if (err instanceof Error) {
+    text = err.message
+  } else {
+    text = String(err)
+  }
   return {content: [{type: 'text', text}], isError: true}
 }
 
 export function paginationParams(page?: number, pageSize?: number): Record<string, string> {
   const params: Record<string, string> = {}
-  if (page) params['page[number]'] = String(page)
-  if (pageSize) params['page[size]'] = String(pageSize)
+  if (page !== undefined) params['page[number]'] = String(page)
+  if (pageSize !== undefined) params['page[size]'] = String(pageSize)
   return params
 }


### PR DESCRIPTION
## Summary

- Adds `adapty mcp` command that starts a Model Context Protocol server over stdin/stdout
- Enables Claude (and any MCP client) to manage Adapty apps, products, paywalls, placements, and access levels directly in conversation
- Uses existing `createAuthenticatedClient()` for auth — `ADAPTY_TOKEN` env var or `~/.config/adapty/config.json`
- All 22 tools follow the `adapty_{resource}_{action}` naming convention

## Tools exposed

| Resource | Tools |
|---|---|
| auth | `adapty_auth_status`, `adapty_auth_whoami` |
| apps | list, get, create, update |
| products | list, get, create, update |
| paywalls | list, get, create, update |
| placements | list, get, create, update |
| access levels | list, get, create, update |

## Architecture

```
Claude (MCP client)
  → JSON-RPC over stdio
  → src/commands/mcp/index.ts   (oclif entry point)
  → src/lib/mcp/server.ts       (tool registration)
  → src/lib/mcp/tools/*.ts      (6 domain files)
  → createAuthenticatedClient   (existing auth helper)
  → ApiClient → Adapty REST API
```

stdout is reserved for JSON-RPC. All logging goes to stderr.

## Claude Desktop config

```json
{
  "mcpServers": {
    "adapty": {
      "command": "adapty",
      "args": ["mcp"]
    }
  }
}
```

## Test plan

- [ ] `adapty mcp` starts without errors
- [ ] `adapty_auth_status` returns `{authenticated: true, email: "..."}` when logged in
- [ ] `adapty_apps_list` returns paginated app list
- [ ] `adapty_apps_create` creates an app (ios + android)
- [ ] `adapty_products_create` enforces android_base_plan_id requirement for non-lifetime
- [ ] Process exits cleanly when Claude Desktop disconnects (no zombie)
- [ ] SIGTERM shuts down gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)