### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapty",
   "description": "Adapty command line interface",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "author": "Adapty team <support@adapty.io>",
   "bin": {
     "adapty": "./bin/run.js"


### PR DESCRIPTION
## Summary

Bumps `package.json` version `0.1.5` → `0.2.0` so the release workflow can publish v0.2.0 to npm.

## Context

Recovery from the failed v0.2.0 release:
- PR #3 merged with `package.json` still at `0.1.5`.
- Manual `v0.2.0` tag/release was created → `onTag.yml` tried `npm publish` and failed with `cannot publish over previously published versions: 0.1.5`.
- Bad tag + GitHub release have been deleted.

Once this lands on `main`, `onPushToMain.yml` will create the `v0.2.0` tag/release on the new commit, and `onTag.yml` will publish to npm.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: `onPushToMain.yml` recreates `v0.2.0` tag + GitHub release
- [ ] `onTag.yml` publishes `adapty@0.2.0` to npm
- [ ] `npm view adapty version` returns `0.2.0`
- [ ] Restore release notes via `gh release edit v0.2.0 --notes-file ...`