### PR TITLE
feat(products): Stripe & Paddle store bindings in products create

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapty",
   "description": "Adapty command line interface",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "Adapty team <support@adapty.io>",
   "bin": {
     "adapty": "./bin/run.js"

--- a/skills/adapty-cli/SKILL.md
+++ b/skills/adapty-cli/SKILL.md
@@ -81,7 +81,7 @@ After collecting all answers, confirm the plan with the user in a summary table,
 Execution order (each step uses output from previous):
 1. `adapty auth login` (if not already authenticated, check with `adapty auth whoami`)
 2. `adapty apps create --title "..." --platform ... --apple-bundle-id/--google-bundle-id ...` → save output: `id` (use as `--app`), `sdk_key` (use in SDK), plus the default access level `id` and `sdk_id` printed after creation
-3. For each product: `adapty products create --app <APP_ID> --title "..." --period ... --access-level-id <DEFAULT_AL_ID> --ios-product-id/--android-product-id ... [--android-base-plan-id ...]` → save product IDs. Android subscriptions (non-lifetime) require `--android-base-plan-id`.
+3. For each product: `adapty products create --app <APP_ID> --title "..." --period ... --access-level-id <DEFAULT_AL_ID> --ios-product-id/--android-product-id ... [--android-base-plan-id ...]` → save product IDs. Android subscriptions (non-lifetime) require `--android-base-plan-id`. Web products bind Stripe/Paddle instead: `--stripe-product-id`+`--stripe-price-id` or `--paddle-product-id`+`--paddle-price-id` (each pair required together).
 4. `adapty paywalls create --app <APP_ID> --title "..." --product-id <ID1> --product-id <ID2> ...` → save paywall ID
 5. For each placement: `adapty placements create --app <APP_ID> --title "..." --developer-id ... --audiences '[{"segment_ids":[],"paywall_id":"<PAYWALL_ID>","priority":0}]'`
    - `--paywall-id <PAYWALL_ID>` is still accepted as legacy shorthand but emits a stderr deprecation warning. Prefer `--audiences` for the canonical default-audience shape.

--- a/skills/adapty-cli/references/cli-commands.md
+++ b/skills/adapty-cli/references/cli-commands.md
@@ -29,10 +29,10 @@ All commands support `--json` for machine-readable output.
 |-----------------------------|--------------------------------------------------|
 | `products list`              | `--app`                                           |
 | `products get <product_id>`  | `--app`                                           |
-| `products create`            | `--app`, `--title`, `--period`, `--access-level-id`, at least one of `--ios-product-id` / `--android-product-id`. Android subscriptions also need `--android-base-plan-id` |
+| `products create`            | `--app`, `--title`, `--period`, `--access-level-id`, at least one store binding (`--ios-product-id` / `--android-product-id` / `--stripe-product-id` / `--paddle-product-id`). Android subscriptions also need `--android-base-plan-id`. Stripe/Paddle each require the product+price pair together: `--stripe-product-id` + `--stripe-price-id`, `--paddle-product-id` + `--paddle-price-id` |
 | `products update <product_id>` | `--app`, `--title`, `--access-level-id`         |
 
-**Immutable on create:** `--period`, `--ios-product-id`, `--android-product-id`, `--android-base-plan-id` cannot be changed after creation.
+**Immutable on create:** `--period` and all store bindings (`--ios-product-id`, `--android-product-id`, `--android-base-plan-id`, `--stripe-product-id`, `--stripe-price-id`, `--paddle-product-id`, `--paddle-price-id`) cannot be changed after creation.
 
 ## Paywalls
 

--- a/src/commands/products/create.ts
+++ b/src/commands/products/create.ts
@@ -27,17 +27,17 @@ static examples = [
 static flags = {
     ...appFlag,
     'access-level-id': Flags.string({description: 'Access level ID (UUID)', required: true}),
-    'android-base-plan-id': Flags.string({description: 'Android base plan ID'}),
-    'android-product-id': Flags.string({description: 'Android product ID'}),
-    'ios-product-id': Flags.string({description: 'iOS product ID'}),
-    'paddle-price-id': Flags.string({description: 'Paddle price ID (requires --paddle-product-id)'}),
-    'paddle-product-id': Flags.string({description: 'Paddle product ID (requires --paddle-price-id)'}),
+    'android-base-plan-id': Flags.string({description: 'Android base plan ID', helpGroup: 'STORE BINDINGS'}),
+    'android-product-id': Flags.string({description: 'Android product ID', helpGroup: 'STORE BINDINGS'}),
+    'ios-product-id': Flags.string({description: 'iOS product ID', helpGroup: 'STORE BINDINGS'}),
+    'paddle-price-id': Flags.string({description: 'Paddle price ID (requires --paddle-product-id)', helpGroup: 'STORE BINDINGS'}),
+    'paddle-product-id': Flags.string({description: 'Paddle product ID (requires --paddle-price-id)', helpGroup: 'STORE BINDINGS'}),
     period: Flags.string({
       description: 'Subscription period (weekly, monthly, two_months, trimonthly, semiannual, annual, lifetime)',
       required: true,
     }),
-    'stripe-price-id': Flags.string({description: 'Stripe price ID (requires --stripe-product-id)'}),
-    'stripe-product-id': Flags.string({description: 'Stripe product ID (requires --stripe-price-id)'}),
+    'stripe-price-id': Flags.string({description: 'Stripe price ID (requires --stripe-product-id)', helpGroup: 'STORE BINDINGS'}),
+    'stripe-product-id': Flags.string({description: 'Stripe product ID (requires --stripe-price-id)', helpGroup: 'STORE BINDINGS'}),
     title: Flags.string({description: 'Product title', required: true}),
   }
 

--- a/src/commands/products/create.ts
+++ b/src/commands/products/create.ts
@@ -16,6 +16,8 @@ const VALID_PERIODS = [
   'lifetime',
 ] as const satisfies readonly ProductPeriod[]
 
+const xor = (a?: string, b?: string) => (a === undefined) !== (b === undefined)
+
 export default class ProductsCreate extends Command {
   static description = 'Create a product with vendor products per platform'
 static enableJsonFlag = true
@@ -28,10 +30,14 @@ static flags = {
     'android-base-plan-id': Flags.string({description: 'Android base plan ID'}),
     'android-product-id': Flags.string({description: 'Android product ID'}),
     'ios-product-id': Flags.string({description: 'iOS product ID'}),
+    'paddle-price-id': Flags.string({description: 'Paddle price ID (requires --paddle-product-id)'}),
+    'paddle-product-id': Flags.string({description: 'Paddle product ID (requires --paddle-price-id)'}),
     period: Flags.string({
       description: 'Subscription period (weekly, monthly, two_months, trimonthly, semiannual, annual, lifetime)',
       required: true,
     }),
+    'stripe-price-id': Flags.string({description: 'Stripe price ID (requires --stripe-product-id)'}),
+    'stripe-product-id': Flags.string({description: 'Stripe product ID (requires --stripe-price-id)'}),
     title: Flags.string({description: 'Product title', required: true}),
   }
 
@@ -42,8 +48,21 @@ static flags = {
       this.error(`Invalid period. Must be one of: ${VALID_PERIODS.join(', ')}`, {exit: 2})
     }
 
-    if (!flags['ios-product-id'] && !flags['android-product-id']) {
-      this.error('At least one of --ios-product-id or --android-product-id is required', {exit: 2})
+    if (xor(flags['stripe-product-id'], flags['stripe-price-id'])) {
+      this.error('--stripe-product-id and --stripe-price-id are required together', {exit: 2})
+    }
+
+    if (xor(flags['paddle-product-id'], flags['paddle-price-id'])) {
+      this.error('--paddle-product-id and --paddle-price-id are required together', {exit: 2})
+    }
+
+    if (
+      !flags['ios-product-id'] &&
+      !flags['android-product-id'] &&
+      !flags['stripe-product-id'] &&
+      !flags['paddle-product-id']
+    ) {
+      this.error('At least one store binding is required (ios/android/stripe/paddle)', {exit: 2})
     }
 
     if (flags['android-product-id'] && !flags['android-base-plan-id'] && flags.period !== 'lifetime') {
@@ -61,6 +80,10 @@ static flags = {
     if (flags['ios-product-id']) body.ios_product_id = flags['ios-product-id']
     if (flags['android-product-id']) body.android_product_id = flags['android-product-id']
     if (flags['android-base-plan-id']) body.android_base_plan_id = flags['android-base-plan-id']
+    if (flags['stripe-product-id']) body.stripe_product_id = flags['stripe-product-id']
+    if (flags['stripe-price-id']) body.stripe_price_id = flags['stripe-price-id']
+    if (flags['paddle-product-id']) body.paddle_product_id = flags['paddle-product-id']
+    if (flags['paddle-price-id']) body.paddle_price_id = flags['paddle-price-id']
 
     const result = await client.post<ProductDTO>(`/apps/${flags.app}/products`, body)
 

--- a/src/lib/api-schemas.ts
+++ b/src/lib/api-schemas.ts
@@ -79,8 +79,12 @@ export interface ProductCreateRequestDTO {
   android_base_plan_id?: null | string
   android_product_id?: null | string
   ios_product_id?: null | string
+  paddle_price_id?: null | string
+  paddle_product_id?: null | string
   period: ProductPeriod
   price_usd?: null | number
+  stripe_price_id?: null | string
+  stripe_product_id?: null | string
   title: string
 }
 

--- a/test/commands/products.test.ts
+++ b/test/commands/products.test.ts
@@ -47,6 +47,40 @@ describe('products', () => {
     })
   })
 
+  it('create maps Stripe bindings to the POST body', async () => {
+    process.env.ADAPTY_TOKEN = 'test-token'
+    fetchStub = mockFetch([PRODUCT_RESPONSE])
+    await runCommand(`products create --app ${TEST_APP_ID} --title Monthly --access-level-id ${TEST_RESOURCE_ID} --period monthly --stripe-product-id prod_x --stripe-price-id price_x`)
+    assertFetch({
+      body: {stripe_price_id: 'price_x', stripe_product_id: 'prod_x'},
+      callIndex: 0,
+      method: 'POST',
+      path: `/apps/${TEST_APP_ID}/products/`,
+      stub: fetchStub,
+    })
+  })
+
+  it('create maps Paddle bindings to the POST body', async () => {
+    process.env.ADAPTY_TOKEN = 'test-token'
+    fetchStub = mockFetch([PRODUCT_RESPONSE])
+    await runCommand(`products create --app ${TEST_APP_ID} --title Monthly --access-level-id ${TEST_RESOURCE_ID} --period monthly --paddle-product-id pro_x --paddle-price-id pri_x`)
+    assertFetch({
+      body: {paddle_price_id: 'pri_x', paddle_product_id: 'pro_x'},
+      callIndex: 0,
+      method: 'POST',
+      path: `/apps/${TEST_APP_ID}/products/`,
+      stub: fetchStub,
+    })
+  })
+
+  it('create rejects a lone --stripe-product-id without a fetch', async () => {
+    process.env.ADAPTY_TOKEN = 'test-token'
+    fetchStub = mockFetch([PRODUCT_RESPONSE])
+    const {error} = await runCommand(`products create --app ${TEST_APP_ID} --title Monthly --access-level-id ${TEST_RESOURCE_ID} --period monthly --stripe-product-id prod_x`)
+    if (fetchStub.called) throw new Error('expected no fetch call')
+    if (!error) throw new Error('expected command to error')
+  })
+
   it('update calls PUT /apps/{app}/products/{id}', async () => {
     process.env.ADAPTY_TOKEN = 'test-token'
     fetchStub = mockFetch([PRODUCT_RESPONSE])


### PR DESCRIPTION
## What

Adds Stripe & Paddle store bindings to `adapty products create`, matching the new Developer API create fields.

New flags (each pair required together, or both omitted):
- `--stripe-product-id` + `--stripe-price-id`
- `--paddle-product-id` + `--paddle-price-id`

```
adapty products create --app <uuid> --title "Premium" --period annual \
  --access-level-id <uuid> \
  --stripe-product-id prod_xxx --stripe-price-id price_xxx \
  --paddle-product-id pro_xxx  --paddle-price-id  pri_xxx
```

## Changes
- `api-schemas.ts` — four optional fields on `ProductCreateRequestDTO` (response types already match).
- `products/create.ts` — flags, per-store "required together" guards, and relaxed the store guard so a Stripe/Paddle-only (web) product with no mobile id is valid. Body mapping via the existing conditional-assign idiom.
- Tests — Stripe map, Paddle map, and lone-flag rejection (no fetch, non-zero exit).
- Docs — `skills/adapty-cli` SKILL + cli-commands reference.

Scope: create-only, mirroring the API (update still edits only title/access_level_id).

## Verification
`pnpm build` / `pnpm test` (33 passing) / `pnpm lint` (0 errors).