### PR TITLE
ci: use GH_RELEASE_TOKEN so release tag triggers publish

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_RELEASE_TOKEN }}
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -53,5 +55,5 @@ jobs:
           name: ${{ steps.version-check.outputs.tag }}
           tag: ${{ steps.version-check.outputs.tag }}
           commit: ${{ github.ref_name }}
-          token: ${{ github.token }}
+          token: ${{ secrets.GH_RELEASE_TOKEN }}
           skipIfReleaseExists: true


### PR DESCRIPTION
## Problem
Tags/releases created by \`onPushToMain.yml\` use the default \`GITHUB_TOKEN\`. GitHub's anti-recursion rule blocks such tags from triggering other workflows, so \`onTag.yml\` (\`push: tags: v*\`) never auto-fires — the tag and release appear, but nothing publishes to npm. Manual dispatch on \`main\` also fails because the \`publish\` environment only allows \`v*\` tag refs.

## Fix
Use the \`GH_RELEASE_TOKEN\` PAT for checkout and the release-action. A tag created by a PAT triggers downstream workflows normally, so \`onTag.yml\` fires on the \`v*\` tag and satisfies the environment's tag policy. Fully automatic, no manual dispatch.

## Requires
- \`GH_RELEASE_TOKEN\` repo secret with Contents: write (already added).

\`onTag.yml\` unchanged.