### PR TITLE
asa campaigns bulk-create / bulk-status (ASA-743)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,28 @@ adapty asa ads create --ad-group UUID --creative-id 4321 --name "Summer ad"
 adapty asa ads update AD_ID [--name "..."] [--status PAUSED]
 ```
 
+Bulk structure creation submits a whole tree — campaigns with nested ad groups, keywords, negative keywords
+and ads — in one call. The input is a JSON structure (the natural path for an AI agent: generate it, pipe it
+in), or a native Apple Ads template converted server-side. The whole payload is validated before anything is
+created — a rejection lists every bad node; on acceptance the command polls progress and prints the final
+report (`success` / `partial` / `failed`, with per-object failures):
+
+```sh
+adapty asa campaigns bulk-create --file structure.json          # JSON structure, waits and reports
+cat structure.json | adapty asa campaigns bulk-create --file -  # same, from stdin
+adapty asa campaigns bulk-create --file structure.json --no-wait
+adapty asa campaigns bulk-create --from-file Campaign_And_Adgroup_Template.xlsx --org-id 1234567
+adapty asa campaigns bulk-create --from-file keywords_template.csv --org-id 1234567 --preview
+adapty asa campaigns bulk-status OPERATION_ID
+```
+
+The structure is `{campaign_group_id | campaign_group_internal_id, campaigns: [...]}` where each campaign
+node either creates (`payload`) or addresses an existing campaign by id (an *anchor*, optionally carrying
+`update_payload`), and nests `ad_groups` with `keywords`, `negative_keywords` and `ads` the same way.
+`--from-file` takes the native Apple Ads templates and needs `--org-id` (the Apple org id from
+`asa orgs list`); `--preview` prints the converted request without creating anything. Conversion issues are
+reported with their sheet, row and column.
+
 Keywords are always applied as a batch, at most 100 per call, and a partial rejection is reported per item:
 
 ```sh

--- a/docs/agent/asa-management.md
+++ b/docs/agent/asa-management.md
@@ -30,6 +30,8 @@ Every `list` and `get` command in this file returns metadata only, no metrics. E
 | `asa campaigns get <id>` | positional UUID | Metadata only. |
 | `asa campaigns create` | `--org`, `--name`, `--adam-id`, `--country` (repeatable), `--daily-budget`; optional `--status` (`ENABLED`/`PAUSED`, no default), `--budget` (lifetime), `--target-cpa`, `--bidding-strategy`, `--supply-source` (repeatable, default `APPSTORE_SEARCH_RESULTS`), `--billing-event` (`IMPRESSIONS`/`TAPS`, default `TAPS`), `--ad-channel-type` (`DISPLAY`/`SEARCH`, default `SEARCH`) | `--org` takes the UUID (`internal_id`) from `asa orgs list`, not that row's numeric `org_id`; `--adam-id` comes from `asa apps list`. `--status` has no default — pass `--status PAUSED` to launch without spending until you enable it. |
 | `asa campaigns update <id>` | at least one of `--name`, `--status`, `--country`, `--daily-budget`, `--budget`, `--target-cpa`, `--bidding-strategy` | |
+| `asa campaigns bulk-create` | exactly one of `--file` (JSON structure, `-` for stdin) / `--from-file` (Apple Ads template, `.xlsx` or keywords `.csv`); `--org-id` required with `--from-file`; optional `--preview`, `--no-wait`, `--poll-interval` (default `5`), `--timeout` (default `900`) | Creates a whole structure — campaigns → ad groups → keywords/negative keywords/ads — as one queued operation. `--org-id` is the exception to this file's UUID rule: it takes the **numeric** `org_id` from `asa orgs list` (Apple's `campaign_group_id`), not the `internal_id` UUID that `campaigns create --org` takes. `--from-file` converts the template server-side first (its own budget — see [Request budgets](#request-budgets)); with `--preview` the command prints the converted request and creates nothing. By default it polls until the operation finishes (`success`/`partial`/`failed`, per-object failures listed); `--no-wait` prints the `operation_id` and returns — follow up with `bulk-status`. |
+| `asa campaigns bulk-status <operation-id>` | positional operation id, printed by `bulk-create` | Progress of one bulk operation: status, applied/failed counts, and the per-object log with each failure's reason. |
 
 ## Ad groups
 
@@ -135,6 +137,7 @@ Every `asa` command is rate limited per company, not per token:
 | catalog lists and gets, automation reads | 120/min |
 | `keywords list` | 30/min, burst 5 per 10s, its own 2-concurrent pool, 60s server timeout |
 | all writes | 20/min |
+| template conversion (`bulk-create --from-file`) | 10/min, one conversion at a time |
 | `whoami` | 60/min |
 
 `keywords list` is the heaviest metadata read in the surface — its own budget is on top of

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapty",
   "description": "Adapty command line interface",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "Adapty team <support@adapty.io>",
   "bin": {
     "adapty": "./bin/run.js"

--- a/src/commands/asa/campaigns/bulk-create.ts
+++ b/src/commands/asa/campaigns/bulk-create.ts
@@ -1,0 +1,214 @@
+import {Command, Flags} from '@oclif/core'
+import {readFile} from 'node:fs/promises'
+import {basename} from 'node:path'
+
+import type {
+  AsaBulkConvertResultDTO,
+  AsaBulkOperationAcceptedDTO,
+  AsaBulkOperationStateDTO,
+  AsaTemplateIssueDTO,
+} from '../../../lib/asa-schemas.js'
+
+import {ApiClient} from '../../../lib/api-client.js'
+import {asaWrite, createAsaClient, noteReplay} from '../../../lib/asa-client.js'
+import {confirmFlags, confirmMutation} from '../../../lib/asa-confirm.js'
+import {idempotencyFlags} from '../../../lib/asa-flags.js'
+import {printResponse} from '../../../lib/output.js'
+
+const TERMINAL_STATUSES = new Set(['failed', 'partial', 'success'])
+
+interface StructureCounts {
+  adGroups: number
+  ads: number
+  campaigns: number
+  keywords: number
+  negativeKeywords: number
+}
+
+export default class AsaCampaignsBulkCreate extends Command {
+  static description =
+    'Create a whole campaign structure (campaigns → ad groups → keywords/negative keywords/ads) in one bulk operation'
+  static enableJsonFlag = true
+  static examples = [
+    '<%= config.bin %> asa campaigns bulk-create --file structure.json',
+    'cat structure.json | <%= config.bin %> asa campaigns bulk-create --file -',
+    '<%= config.bin %> asa campaigns bulk-create --from-file Campaign_And_Adgroup_Template.xlsx --org-id 1234567',
+    '<%= config.bin %> asa campaigns bulk-create --from-file keywords_template.csv --org-id 1234567 --preview',
+  ]
+  static flags = {
+    ...confirmFlags,
+    ...idempotencyFlags,
+    file: Flags.string({
+      description: 'JSON file with the campaign structure (the POST /bulk-operations/ body); use "-" for stdin',
+      exactlyOne: ['file', 'from-file'],
+    }),
+    'from-file': Flags.string({
+      description: 'Apple Ads bulk template (Campaign_And_Adgroup_Template.xlsx or keywords .csv) to convert and submit',
+    }),
+    'org-id': Flags.integer({
+      description: 'Apple org id (campaign_group_id) the converted template will target; required with --from-file',
+    }),
+    'poll-interval': Flags.integer({default: 5, description: 'Seconds between progress polls'}),
+    preview: Flags.boolean({
+      description: 'With --from-file: print the converted request and stop, nothing is created',
+    }),
+    timeout: Flags.integer({default: 900, description: 'Max seconds to wait for the operation to finish'}),
+    wait: Flags.boolean({
+      allowNo: true,
+      default: true,
+      description: 'Poll the operation until it finishes; --no-wait returns the operation id immediately',
+    }),
+  }
+
+  async run(): Promise<AsaBulkOperationStateDTO | Record<string, unknown>> {
+    const {flags} = await this.parse(AsaCampaignsBulkCreate)
+    const client = await createAsaClient(this.config)
+
+    const body = flags['from-file'] ? await this.convertTemplate(client, flags) : await this.readStructure(flags.file!)
+    if (flags.preview) {
+      this.log(JSON.stringify(body, null, 2))
+      return body
+    }
+
+    const counts = this.countStructure(body)
+    const summary =
+      `Bulk-create: ${counts.campaigns} campaign node(s), ${counts.adGroups} ad group(s), ` +
+      `${counts.keywords} keyword(s), ${counts.negativeKeywords} negative keyword(s), ${counts.ads} ad(s)`
+    await confirmMutation(this, {body, method: 'POST', path: '/bulk-operations/', summary}, flags.yes)
+
+    const {replayed, result} = await asaWrite<AsaBulkOperationAcceptedDTO>(client, 'post', '/bulk-operations', {
+      body,
+      idempotencyKey: flags['idempotency-key'],
+    })
+    noteReplay(replayed, this.log.bind(this))
+    this.log(`Operation accepted: ${result.operation_id}`)
+
+    if (!flags.wait) {
+      this.log(`Check progress with: adapty asa campaigns bulk-status ${result.operation_id}`)
+      return {operation_id: result.operation_id}
+    }
+
+    const state = await this.waitForCompletion(client, result.operation_id, flags['poll-interval'], flags.timeout)
+    this.report(state)
+    return state
+  }
+
+  private async convertTemplate(
+    client: ApiClient,
+    flags: {'from-file'?: string; 'org-id'?: number;},
+  ): Promise<Record<string, unknown>> {
+    if (flags['org-id'] === undefined) this.error('--org-id is required with --from-file.', {exit: 2})
+
+    const path = flags['from-file']!
+    let content: Buffer
+    try {
+      content = await readFile(path)
+    } catch {
+      this.error(`Cannot read file: ${path}`, {exit: 2})
+    }
+
+    const form = new FormData()
+    form.append('file', new Blob([new Uint8Array(content)]), basename(path))
+    form.append('campaign_group_id', String(flags['org-id']))
+    const result = await client.postForm<AsaBulkConvertResultDTO>('/bulk-operations/convert', form)
+
+    for (const warning of result.warnings) this.warn(this.formatIssue(warning))
+    if (result.errors.length > 0 || result.request === null) {
+      for (const issue of result.errors) this.log(this.formatIssue(issue))
+      this.error(`Template conversion failed with ${result.errors.length} error(s); nothing was created.`, {exit: 2})
+    }
+
+    return result.request
+  }
+
+  private countStructure(body: Record<string, unknown>): StructureCounts {
+    const counts: StructureCounts = {adGroups: 0, ads: 0, campaigns: 0, keywords: 0, negativeKeywords: 0}
+    const campaigns = Array.isArray(body.campaigns) ? body.campaigns : []
+    counts.campaigns = campaigns.length
+    for (const campaign of campaigns) {
+      if (typeof campaign !== 'object' || campaign === null) continue
+      const campaignNode = campaign as Record<string, unknown>
+      counts.negativeKeywords += Array.isArray(campaignNode.negative_keywords) ? campaignNode.negative_keywords.length : 0
+      const adGroups = Array.isArray(campaignNode.ad_groups) ? campaignNode.ad_groups : []
+      counts.adGroups += adGroups.length
+      for (const adGroup of adGroups) {
+        if (typeof adGroup !== 'object' || adGroup === null) continue
+        const adGroupNode = adGroup as Record<string, unknown>
+        counts.keywords += Array.isArray(adGroupNode.keywords) ? adGroupNode.keywords.length : 0
+        counts.negativeKeywords += Array.isArray(adGroupNode.negative_keywords) ? adGroupNode.negative_keywords.length : 0
+        counts.ads += Array.isArray(adGroupNode.ads) ? adGroupNode.ads.length : 0
+      }
+    }
+
+    return counts
+  }
+
+  private formatIssue(issue: AsaTemplateIssueDTO): string {
+    const place = [issue.sheet, issue.row === null ? undefined : `row ${issue.row}`, issue.column ?? undefined]
+      .filter(Boolean)
+      .join(', ')
+    return place ? `${place}: ${issue.message}` : issue.message
+  }
+
+  private async readStructure(source: string): Promise<Record<string, unknown>> {
+    let raw: string
+    if (source === '-') {
+      const chunks: Buffer[] = []
+      for await (const chunk of process.stdin) chunks.push(chunk as Buffer)
+      raw = Buffer.concat(chunks).toString('utf8')
+    } else {
+      try {
+        raw = await readFile(source, 'utf8')
+      } catch {
+        this.error(`Cannot read file: ${source}`, {exit: 2})
+      }
+    }
+
+    try {
+      return JSON.parse(raw) as Record<string, unknown>
+    } catch {
+      this.error('The structure is not valid JSON.', {exit: 2})
+    }
+  }
+
+  private report(state: AsaBulkOperationStateDTO): void {
+    const {counts} = state
+    this.log(`Finished: ${state.status} — ${counts.applied}/${counts.total} applied, ${counts.failed} failed`)
+    const failedObjects = state.objects.filter((object) => object.status === 'failed')
+    for (const object of failedObjects) {
+      printResponse(object as unknown as Record<string, unknown>, this.log.bind(this))
+      this.log('---')
+    }
+
+    if (state.status === 'failed') this.error('Bulk operation failed.', {exit: 1})
+    if (state.status === 'partial') this.warn('Some objects were not created — see the failures above.')
+  }
+
+  private async waitForCompletion(
+    client: ApiClient,
+    operationId: string,
+    pollIntervalSeconds: number,
+    timeoutSeconds: number,
+  ): Promise<AsaBulkOperationStateDTO> {
+    const startedAt = Date.now()
+    let lastProgress = ''
+    for (;;) {
+      const state = await client.get<AsaBulkOperationStateDTO>(`/bulk-operations/${operationId}`)
+      const progress = `${state.status}: ${state.counts.applied}/${state.counts.total} applied, ${state.counts.failed} failed`
+      if (progress !== lastProgress) {
+        this.log(progress)
+        lastProgress = progress
+      }
+
+      if (TERMINAL_STATUSES.has(state.status)) return state
+      if ((Date.now() - startedAt) / 1000 >= timeoutSeconds) {
+        this.warn(`Still ${state.status} after ${timeoutSeconds}s — check later with: adapty asa campaigns bulk-status ${operationId}`)
+        return state
+      }
+
+      await new Promise((resolve) => {
+        setTimeout(resolve, pollIntervalSeconds * 1000)
+      })
+    }
+  }
+}

--- a/src/commands/asa/campaigns/bulk-status.ts
+++ b/src/commands/asa/campaigns/bulk-status.ts
@@ -1,0 +1,32 @@
+import {Args, Command} from '@oclif/core'
+
+import type {AsaBulkOperationStateDTO} from '../../../lib/asa-schemas.js'
+
+import {createAsaClient} from '../../../lib/asa-client.js'
+import {asaPaginationFlags} from '../../../lib/asa-flags.js'
+import {isValidUuid, paginationParams} from '../../../lib/flags.js'
+import {printResponse} from '../../../lib/output.js'
+
+export default class AsaCampaignsBulkStatus extends Command {
+  static args = {
+    'operation-id': Args.string({description: 'Bulk operation ID returned by bulk-create', required: true}),
+  }
+  static description = 'Progress board of one bulk operation: counts, pipelines and the per-object log'
+  static enableJsonFlag = true
+  static examples = ['<%= config.bin %> asa campaigns bulk-status 660e8400-e29b-41d4-a716-446655440001']
+  static flags = {
+    ...asaPaginationFlags,
+  }
+
+  async run(): Promise<AsaBulkOperationStateDTO> {
+    const {args, flags} = await this.parse(AsaCampaignsBulkStatus)
+    const operationId = args['operation-id']
+    if (!isValidUuid(operationId)) this.error('Invalid operation ID format.', {exit: 2})
+
+    const client = await createAsaClient(this.config)
+    const state = await client.get<AsaBulkOperationStateDTO>(`/bulk-operations/${operationId}`, paginationParams(flags))
+
+    printResponse(state as unknown as Record<string, unknown>, this.log.bind(this))
+    return state
+  }
+}

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -57,6 +57,10 @@ export class ApiClient {
     )
   }
 
+  async postForm<T = unknown>(path: string, form: FormData, params?: QueryParams, opts?: RequestOptions): Promise<T> {
+    return this.request<T>(this.buildUrl(path, params), {body: form, method: 'POST'}, opts)
+  }
+
   async put<T = unknown>(path: string, body?: unknown, params?: QueryParams, opts?: RequestOptions): Promise<T> {
     return this.request<T>(
       this.buildUrl(path, params),
@@ -97,7 +101,7 @@ export class ApiClient {
       'User-Agent': this.userAgent,
     }
 
-    if (init.body) {
+    if (init.body && !(init.body instanceof FormData)) {
       headers['Content-Type'] = 'application/json'
     }
 

--- a/src/lib/asa-schemas.ts
+++ b/src/lib/asa-schemas.ts
@@ -319,3 +319,50 @@ export interface AsaNegativeKeywordMutationDTO {
 export interface AsaAutomationMutationDTO {
   automation: AsaAutomationDTO | null
 }
+
+export type AsaBulkOperationStatus = 'failed' | 'partial' | 'pending' | 'running' | 'success'
+
+export interface AsaBulkOperationAcceptedDTO {
+  operation_id: string
+}
+
+export interface AsaBulkOperationCountsDTO {
+  applied: number
+  failed: number
+  pending: number
+  total: number
+}
+
+export interface AsaBulkOperationObjectDTO {
+  apple_error_code: null | string
+  apple_error_message: null | string
+  entity_kind: string
+  external_id: null | number
+  item_ref: string
+  status: string
+  step_type: string
+}
+
+export interface AsaBulkOperationStateDTO {
+  counts: AsaBulkOperationCountsDTO
+  created_at: string
+  finished_at: null | string
+  objects: AsaBulkOperationObjectDTO[]
+  operation_id: string
+  pipelines: Record<string, unknown>[]
+  started_at: null | string
+  status: AsaBulkOperationStatus
+}
+
+export interface AsaTemplateIssueDTO {
+  column: null | string
+  message: string
+  row: null | number
+  sheet: null | string
+}
+
+export interface AsaBulkConvertResultDTO {
+  errors: AsaTemplateIssueDTO[]
+  request: null | Record<string, unknown>
+  warnings: AsaTemplateIssueDTO[]
+}

--- a/test/commands/asa-bulk.test.ts
+++ b/test/commands/asa-bulk.test.ts
@@ -1,0 +1,207 @@
+import {runCommand} from '@oclif/test'
+import {expect} from 'chai'
+import {mkdtemp, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import sinon from 'sinon'
+
+import {ASA_API_BASE, assertFetch, mockFetch, restoreFetch, TEST_RESOURCE_ID} from '../helpers/mock-fetch.js'
+
+const STRUCTURE = {
+  campaign_group_id: 555_777,
+  campaigns: [
+    {
+      ad_groups: [
+        {
+          keywords: [{match_type: 'BROAD', text: 'meditation app'}],
+          payload: {name: 'Brand', start_time: '2026-08-01T00:00:00Z', status: 'ENABLED'},
+        },
+      ],
+      payload: {
+        ad_channel_type: 'SEARCH',
+        adam_id: 123_456,
+        billing_event: 'TAPS',
+        countries_or_regions: ['US'],
+        daily_budget_amount: {amount: '100', currency: 'USD'},
+        name: 'US Search',
+        status: 'ENABLED',
+        supply_sources: ['APPSTORE_SEARCH_RESULTS'],
+      },
+    },
+  ],
+}
+
+const ACCEPTED = {operation_id: TEST_RESOURCE_ID}
+
+function state(status: string, applied: number, failed = 0) {
+  return {
+    counts: {applied, failed, pending: 3 - applied - failed, total: 3},
+    created_at: '2026-08-13T10:00:00Z',
+    finished_at: null,
+    objects: [],
+    operation_id: TEST_RESOURCE_ID,
+    pipelines: [],
+    started_at: null,
+    status,
+  }
+}
+
+async function structureFile(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'adapty-bulk-'))
+  const path = join(dir, 'structure.json')
+  await writeFile(path, JSON.stringify(STRUCTURE))
+  return path
+}
+
+describe('asa bulk', () => {
+  describe('campaigns bulk-create', () => {
+  let fetchStub: sinon.SinonStub
+
+  beforeEach(() => {
+    process.env.ADAPTY_TOKEN = 'dev_live_test'
+    delete process.env.ADAPTY_ASA_API_URL
+  })
+
+  afterEach(() => {
+    restoreFetch(fetchStub)
+    delete process.env.ADAPTY_TOKEN
+  })
+
+  it('sends the structure verbatim and polls until the terminal status', async () => {
+    fetchStub = mockFetch([ACCEPTED, state('running', 1), state('success', 3)])
+    const {stdout} = await runCommand(`asa campaigns bulk-create --yes --file ${await structureFile()} --poll-interval 0`)
+
+    assertFetch({base: ASA_API_BASE, body: STRUCTURE, callIndex: 0, method: 'POST', path: '/bulk-operations/', stub: fetchStub})
+    const pollUrl = fetchStub.getCall(1).args[0] as string
+    expect(pollUrl).to.contain(`/bulk-operations/${TEST_RESOURCE_ID}/`)
+    expect(stdout).to.contain(`Operation accepted: ${TEST_RESOURCE_ID}`)
+    expect(stdout).to.contain('running: 1/3 applied, 0 failed')
+    expect(stdout).to.contain('Finished: success — 3/3 applied, 0 failed')
+  })
+
+  it('returns the operation id immediately with --no-wait', async () => {
+    fetchStub = mockFetch([ACCEPTED])
+    const {stdout} = await runCommand(`asa campaigns bulk-create --yes --file ${await structureFile()} --no-wait`)
+
+    expect(fetchStub.callCount).to.equal(1)
+    expect(stdout).to.contain(`bulk-status ${TEST_RESOURCE_ID}`)
+  })
+
+  it('exits non-zero when the operation fails', async () => {
+    fetchStub = mockFetch([ACCEPTED, state('failed', 0, 3)])
+    const {error} = await runCommand(`asa campaigns bulk-create --yes --file ${await structureFile()} --poll-interval 0`)
+
+    expect(error?.message).to.contain('Bulk operation failed')
+  })
+
+  it('refuses to run from a script unless --yes is passed', async () => {
+    fetchStub = mockFetch([ACCEPTED])
+    const {stderr} = await runCommand(`asa campaigns bulk-create --json --file ${await structureFile()}`)
+
+    expect(stderr).to.contain('--yes')
+    expect(fetchStub.callCount).to.equal(0)
+  })
+
+  it('rejects a file that is not valid JSON without calling the API', async () => {
+    fetchStub = mockFetch([ACCEPTED])
+    const dir = await mkdtemp(join(tmpdir(), 'adapty-bulk-'))
+    const path = join(dir, 'broken.json')
+    await writeFile(path, 'not json at all')
+    const {error} = await runCommand(`asa campaigns bulk-create --yes --file ${path}`)
+
+    expect(error?.message).to.contain('not valid JSON')
+    expect(fetchStub.callCount).to.equal(0)
+  })
+
+  it('converts an Apple template and submits the converted request', async () => {
+    const converted = {errors: [], request: STRUCTURE, warnings: []}
+    fetchStub = mockFetch([converted, ACCEPTED, state('success', 3)])
+    const dir = await mkdtemp(join(tmpdir(), 'adapty-bulk-'))
+    const path = join(dir, 'keywords_template.csv')
+    await writeFile(path, 'Action,Keyword\nCREATE,yoga\n')
+    const {stdout} = await runCommand(
+      `asa campaigns bulk-create --yes --from-file ${path} --org-id 555777 --poll-interval 0`,
+    )
+
+    const convertInit = fetchStub.getCall(0).args[1] as {body: FormData; method: string}
+    expect(convertInit.method).to.equal('POST')
+    expect(convertInit.body).to.be.instanceOf(FormData)
+    expect(convertInit.body.get('campaign_group_id')).to.equal('555777')
+    expect((convertInit.body.get('file') as File).name).to.equal('keywords_template.csv')
+    assertFetch({base: ASA_API_BASE, body: STRUCTURE, callIndex: 1, method: 'POST', path: '/bulk-operations/', stub: fetchStub})
+    expect(stdout).to.contain('Finished: success')
+  })
+
+  it('prints conversion issues with their file position and creates nothing', async () => {
+    const converted = {
+      errors: [{column: 'Bid', message: 'not a number', row: 3, sheet: null}],
+      request: null,
+      warnings: [],
+    }
+    fetchStub = mockFetch([converted])
+    const dir = await mkdtemp(join(tmpdir(), 'adapty-bulk-'))
+    const path = join(dir, 'keywords_template.csv')
+    await writeFile(path, 'Action,Keyword\nCREATE,yoga\n')
+    const {error, stdout} = await runCommand(`asa campaigns bulk-create --yes --from-file ${path} --org-id 555777`)
+
+    expect(stdout).to.contain('row 3, Bid: not a number')
+    expect(error?.message).to.contain('conversion failed')
+    expect(fetchStub.callCount).to.equal(1)
+  })
+
+  it('with --preview prints the converted request and stops', async () => {
+    const converted = {errors: [], request: STRUCTURE, warnings: []}
+    fetchStub = mockFetch([converted])
+    const dir = await mkdtemp(join(tmpdir(), 'adapty-bulk-'))
+    const path = join(dir, 'keywords_template.csv')
+    await writeFile(path, 'Action,Keyword\nCREATE,yoga\n')
+    const {stdout} = await runCommand(
+      `asa campaigns bulk-create --yes --from-file ${path} --org-id 555777 --preview`,
+    )
+
+    expect(fetchStub.callCount).to.equal(1)
+    expect(JSON.parse(stdout)).to.deep.equal(STRUCTURE)
+  })
+
+  it('requires --org-id together with --from-file', async () => {
+    fetchStub = mockFetch([])
+    const {error} = await runCommand('asa campaigns bulk-create --yes --from-file whatever.csv')
+
+    expect(error?.message).to.contain('--org-id')
+    expect(fetchStub.callCount).to.equal(0)
+  })
+  })
+
+  describe('campaigns bulk-status', () => {
+  let fetchStub: sinon.SinonStub
+
+  beforeEach(() => {
+    process.env.ADAPTY_TOKEN = 'dev_live_test'
+    delete process.env.ADAPTY_ASA_API_URL
+  })
+
+  afterEach(() => {
+    restoreFetch(fetchStub)
+    delete process.env.ADAPTY_TOKEN
+  })
+
+  it('fetches one operation with the paging flags', async () => {
+    fetchStub = mockFetch([state('partial', 2, 1)])
+    const {stdout} = await runCommand(`asa campaigns bulk-status ${TEST_RESOURCE_ID} --page 3 --page-size 50`)
+
+    const url = fetchStub.getCall(0).args[0] as string
+    expect(url).to.contain(`/bulk-operations/${TEST_RESOURCE_ID}/`)
+    expect(url).to.contain(`${encodeURIComponent('page[number]')}=3`)
+    expect(url).to.contain(`${encodeURIComponent('page[size]')}=50`)
+    expect(stdout).to.contain('Status: partial')
+  })
+
+  it('rejects a malformed operation id before calling the API', async () => {
+    fetchStub = mockFetch([])
+    const {error} = await runCommand('asa campaigns bulk-status not-a-uuid')
+
+    expect(error?.message).to.contain('Invalid operation ID')
+    expect(fetchStub.callCount).to.equal(0)
+  })
+})
+})


### PR DESCRIPTION
Bulk structure creation for the CLI: `asa campaigns bulk-create` submits a whole campaign tree from a JSON file or stdin, or converts a native Apple Ads template (`--from-file` + `--org-id`, `--preview` to inspect without creating). Validation issues are printed with sheet/row/column; on accept the command polls progress (`--no-wait` / `--poll-interval` / `--timeout`) and prints the final report with per-object failures. `asa campaigns bulk-status` re-attaches to an operation. Adds multipart support to ApiClient. 11 tests.