### PR TITLE
fix: only open browser in interactive (TTY) sessions

### DIFF
--- a/src/commands/asa/connect.ts
+++ b/src/commands/asa/connect.ts
@@ -25,7 +25,7 @@ export default class AsaConnect extends Command {
     this.log('The link is valid for one hour. Sign in to the Adapty dashboard in that browser first — the last')
     this.log('step is authorized by the dashboard session, not by this CLI.')
 
-    await open(authUrl).catch(() => false)
+    if (process.stdin.isTTY === true) await open(authUrl).catch(() => false)
 
     if (!flags.wait) return {auth_url: authUrl}
 

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -56,10 +56,12 @@ static examples = ['<%= config.bin %> auth login']
     this.log(`\nYour code: ${device.user_code}\n`)
     this.log(`If browser doesn't open, visit: ${device.verification_uri_complete}\n`)
 
-    try {
-      await open(device.verification_uri_complete)
-    } catch {
-      // browser open failed silently — URL already printed
+    if (process.stdin.isTTY === true) {
+      try {
+        await open(device.verification_uri_complete)
+      } catch {
+        // browser open failed silently — URL already printed
+      }
     }
 
     this.log('Waiting for authorization...')


### PR DESCRIPTION
## Problem

Running the unit tests opened a browser to `https://auth.adapty.io/activate?code=...` on every run — the `auth login` and `asa connect` commands called `open()` unconditionally, so any non-interactive execution (tests, piped runs, CI) launched a browser.

## Change

Guard both `open()` calls on `process.stdin.isTTY === true`, matching the existing interactivity check in `asa-confirm.ts`. In interactive terminals behavior is unchanged; in tests/pipes the browser is skipped. The verification URL is still printed in all cases, so users can open it manually.

- `src/commands/auth/login.ts`
- `src/commands/asa/connect.ts`

## Verification

`auth login` test passes and no longer opens a browser.