### PR TITLE
feat: asa max conversions and loc invoicing flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,15 @@ Campaign structure. These lists return metadata only — numbers come from `asa 
 adapty asa campaigns list
 adapty asa campaigns get CAMPAIGN_ID
 adapty asa campaigns create --org UUID --name "Winter push" --adam-id 123456 --country US --daily-budget 50
+adapty asa campaigns create --org UUID --name "LOC push" --adam-id 123456 --country US --daily-budget 50 \
+  --invoice-advertiser "Acme Inc" --invoice-order-number PO-42 --invoice-contact-name "Jane Doe" \
+  --invoice-contact-email jane@acme.com --invoice-billing-email billing@acme.com   # payment_model LOC
 adapty asa campaigns update CAMPAIGN_ID [--status PAUSED] [--daily-budget 80] [--country US]
 
 adapty asa ad-groups list
 adapty asa ad-groups get AD_GROUP_ID
 adapty asa ad-groups create --campaign UUID --name "Brand terms" --default-bid 1.20
+adapty asa ad-groups create --campaign UUID --name "Automated Max Conv" --automated   # Max Conversions campaigns
 adapty asa ad-groups update AD_GROUP_ID [--default-bid 1.50] [--status PAUSED]
 
 adapty asa ads list

--- a/docs/agent/asa-management.md
+++ b/docs/agent/asa-management.md
@@ -46,9 +46,10 @@ adapty asa ad-groups create --campaign CAMPAIGN_UUID --name "Automated Max Conv"
 ```
 
 `--automated` sends `automated_keywords_required: true` and `automated_keywords_opt_in: true`, omits `start_time`
-(Apple rejects a schedule on an automated group — combining it with `--start-time` exits 2) and makes `--default-bid`
-optional (Apple reports the bid as `0` when omitted). A plain ad group, even with `--automated-keywords`, does not
-satisfy the requirement.
+(Apple schedules the automated group itself — combining it with `--start-time` exits 2), must stay `ENABLED`
+(`--status PAUSED` exits 2; pause the campaign instead) and makes `--default-bid` optional (Apple reports the bid as
+`0` when omitted). A plain ad group, even with `--automated-keywords`, does not satisfy the requirement. On the
+campaign, `--target-cpa` must be lower than `--daily-budget`.
 
 ### Line of credit (LOC) organizations
 
@@ -73,7 +74,7 @@ Invoicing Options. They map to `loc_invoice_details` in the request: advertiser 
 |---|---|---|
 | `asa ad-groups list` | scope filters only | Metadata only. |
 | `asa ad-groups get <id>` | positional UUID | Metadata only. |
-| `asa ad-groups create` | `--campaign`, `--name`, `--default-bid` (optional with `--automated`); optional `--automated` | Apple also requires a pricing model and a start time; the CLI defaults `--pricing-model` to `CPC` (the only other option is `CPM`) and `--start-time` to today if you don't pass them. `--automated` creates the automated ad group a Max Conversions campaign needs: it implies automated keywords, sends no `start_time` (exits 2 if `--start-time` is also given) and does not require `--default-bid` — see [Max Conversions](#max-conversions-campaigns). |
+| `asa ad-groups create` | `--campaign`, `--name`, `--default-bid` (optional with `--automated`); optional `--automated` | Apple also requires a pricing model and a start time; the CLI defaults `--pricing-model` to `CPC` (the only other option is `CPM`) and `--start-time` to today if you don't pass them. `--automated` creates the automated ad group a Max Conversions campaign needs: it implies automated keywords, sends no `start_time` (exits 2 if `--start-time` is also given), must be `ENABLED` (exits 2 on `--status PAUSED`) and does not require `--default-bid` — see [Max Conversions](#max-conversions-campaigns). |
 | `asa ad-groups update <id>` | at least one field | The campaign is resolved server-side and is never passed on update. |
 
 ## Ads

--- a/docs/agent/asa-management.md
+++ b/docs/agent/asa-management.md
@@ -20,7 +20,7 @@ Every `list` and `get` command in this file returns metadata only, no metrics. E
 | `asa whoami` | none | Company, how access was granted, Apple connection state. Run this first. No connected Apple Ads account or no active Ads Manager subscription answers `402 ads_manager_subscription_required` on every other `asa` command. |
 | `asa connect` | `--no-wait` optional | Prints the Apple authorization link and waits for the link to be completed; `--no-wait` returns immediately instead of waiting. |
 | `asa apps list` | pagination only | Apps promoted in Apple Search Ads. Its rows supply `--adam-id` for `campaigns create`. |
-| `asa orgs list` | pagination only | Apple Search Ads organizations. Each row carries two identifiers, not interchangeable: `internal_id` (a UUID) and `org_id` (Apple's numeric id). `--org` on `campaigns create` takes `internal_id` — passing the numeric `org_id` fails with "Invalid org ID format." |
+| `asa orgs list` | pagination only | Apple Search Ads organizations. Each row carries two identifiers, not interchangeable: `internal_id` (a UUID) and `org_id` (Apple's numeric id). `--org` on `campaigns create` takes `internal_id` — passing the numeric `org_id` fails with "Invalid org ID format." `payment_model` (`LOC`/`PAYG`) tells you whether campaigns in that organization need Invoicing Options — see [Line of credit](#line-of-credit-loc-organizations). |
 
 ## Campaigns
 
@@ -28,11 +28,44 @@ Every `list` and `get` command in this file returns metadata only, no metrics. E
 |---|---|---|
 | `asa campaigns list` | scope filters only | Metadata only. |
 | `asa campaigns get <id>` | positional UUID | Metadata only. |
-| `asa campaigns create` | `--org`, `--name`, `--adam-id`, `--country` (repeatable), `--daily-budget`; optional `--status` (`ENABLED`/`PAUSED`, no default), `--budget` (lifetime), `--target-cpa`, `--bidding-strategy`, `--supply-source` (repeatable, default `APPSTORE_SEARCH_RESULTS`), `--billing-event` (`IMPRESSIONS`/`TAPS`, default `TAPS`), `--ad-channel-type` (`DISPLAY`/`SEARCH`, default `SEARCH`) | `--org` takes the UUID (`internal_id`) from `asa orgs list`, not that row's numeric `org_id`; `--adam-id` comes from `asa apps list`. `--status` has no default — pass `--status PAUSED` to launch without spending until you enable it. |
-| `asa campaigns update <id>` | at least one of `--name`, `--status`, `--country`, `--daily-budget`, `--budget`, `--target-cpa`, `--bidding-strategy` | |
+| `asa campaigns create` | `--org`, `--name`, `--adam-id`, `--country` (repeatable), `--daily-budget`; optional `--status` (`ENABLED`/`PAUSED`, no default), `--budget` (lifetime), `--target-cpa`, `--bidding-strategy`, `--supply-source` (repeatable, default `APPSTORE_SEARCH_RESULTS`), `--billing-event` (`IMPRESSIONS`/`TAPS`, default `TAPS`), `--ad-channel-type` (`DISPLAY`/`SEARCH`, default `SEARCH`), `--invoice-advertiser`, `--invoice-order-number`, `--invoice-contact-name`, `--invoice-contact-email`, `--invoice-billing-email` (all five together, LOC organizations only) | `--org` takes the UUID (`internal_id`) from `asa orgs list`, not that row's numeric `org_id`; `--adam-id` comes from `asa apps list`. `--status` has no default — pass `--status PAUSED` to launch without spending until you enable it. The response carries `serving_status` and `serving_state_reasons`; when the campaign is `NOT_RUNNING` the command prints the reason and the fixing command — see [Max Conversions](#max-conversions-campaigns) and [Line of credit](#line-of-credit-loc-organizations). |
+| `asa campaigns update <id>` | at least one of `--name`, `--status`, `--country`, `--daily-budget`, `--budget`, `--target-cpa`, `--bidding-strategy`, or `--invoice-advertiser`, `--invoice-order-number`, `--invoice-contact-name`, `--invoice-contact-email`, `--invoice-billing-email` together | The `--invoice-*` flags replace the stored Invoicing Options as a whole — pass all five, a partial set exits 2 before the network. |
 | `asa campaigns bulk-create` | exactly one of `--file` (JSON structure, `-` for stdin) / `--from-file` (Apple Ads template, `.xlsx` or keywords `.csv`); `--org-id` required with `--from-file`; optional `--preview`, `--no-wait`, `--poll-interval` (default `5`), `--timeout` (default `900`) | Creates a whole structure — campaigns → ad groups → keywords/negative keywords/ads — as one queued operation. `--org-id` is the exception to this file's UUID rule: it takes the **numeric** `org_id` from `asa orgs list` (Apple's `campaign_group_id`), not the `internal_id` UUID that `campaigns create --org` takes. `--from-file` converts the template server-side first (its own budget — see [Request budgets](#request-budgets)); with `--preview` the command prints the converted request and creates nothing. By default it polls until the operation finishes (`success`/`partial`/`failed`, per-object failures listed); `--no-wait` prints the `operation_id` and returns — follow up with `bulk-status`. |
 | `asa campaigns bulk-status <operation-id>` | positional operation id, printed by `bulk-create` | Progress of one bulk operation: status, applied/failed counts, and the per-object log with each failure's reason. |
 | `asa campaigns bulk-list` | optional `--status` (`pending`/`running`/`success`/`partial`/`failed`, repeatable), `--app` (UUID), `--created-from`/`--created-to` (YYYY-MM-DD) | This company's bulk operations, newest first — one row per operation with its verdict and timestamps, no per-object detail. Use it to find an `operation_id` you lost or to check what ran recently, then drill in with `bulk-status`. Cheap catalog read. |
+
+### Max Conversions campaigns
+
+A campaign with `--bidding-strategy MAX_CONVERSIONS` is created fine but stays `NOT_RUNNING` with
+`serving_state_reasons: ["AUTOMATED_KEYWORDS_REQUIRED_AD_GROUP_MISSING"]` until it has an **automated ad group**.
+Always create the pair:
+
+```sh
+adapty asa campaigns create --org ORG_UUID --name "Max Conv" --adam-id 123456 --country US --daily-budget 50 --bidding-strategy MAX_CONVERSIONS
+adapty asa ad-groups create --campaign CAMPAIGN_UUID --name "Automated Max Conv" --automated
+```
+
+`--automated` sends `automated_keywords_required: true` and `automated_keywords_opt_in: true`, omits `start_time`
+(Apple rejects a schedule on an automated group — combining it with `--start-time` exits 2) and makes `--default-bid`
+optional (Apple reports the bid as `0` when omitted). A plain ad group, even with `--automated-keywords`, does not
+satisfy the requirement.
+
+### Line of credit (LOC) organizations
+
+`asa orgs list` shows each organization's `payment_model`. When it is `LOC`, Apple requires Invoicing Options on
+every campaign — without them the campaign is created but sits `NOT_RUNNING` with
+`serving_state_reasons: ["MISSING_BO_OR_INVOICING_FIELDS"]`. Pass all five flags together (a partial set exits 2
+before the network):
+
+```sh
+adapty asa campaigns create --org ORG_UUID --name "LOC push" --adam-id 123456 --country US --daily-budget 50 \
+  --invoice-advertiser "Acme Inc" --invoice-order-number PO-42 --invoice-contact-name "Jane Doe" \
+  --invoice-contact-email jane@acme.com --invoice-billing-email billing@acme.com
+```
+
+For a campaign that already exists, the same five flags on `asa campaigns update <id>` set (or replace) its
+Invoicing Options. They map to `loc_invoice_details` in the request: advertiser → `client_name`, order number →
+`order_number`, contact name → `buyer_name`, contact email → `buyer_email`, billing email → `billing_contact_email`.
 
 ## Ad groups
 
@@ -40,7 +73,7 @@ Every `list` and `get` command in this file returns metadata only, no metrics. E
 |---|---|---|
 | `asa ad-groups list` | scope filters only | Metadata only. |
 | `asa ad-groups get <id>` | positional UUID | Metadata only. |
-| `asa ad-groups create` | `--campaign`, `--name`, `--default-bid` | Apple also requires a pricing model and a start time; the CLI defaults `--pricing-model` to `CPC` (the only other option is `CPM`) and `--start-time` to today if you don't pass them. |
+| `asa ad-groups create` | `--campaign`, `--name`, `--default-bid` (optional with `--automated`); optional `--automated` | Apple also requires a pricing model and a start time; the CLI defaults `--pricing-model` to `CPC` (the only other option is `CPM`) and `--start-time` to today if you don't pass them. `--automated` creates the automated ad group a Max Conversions campaign needs: it implies automated keywords, sends no `start_time` (exits 2 if `--start-time` is also given) and does not require `--default-bid` — see [Max Conversions](#max-conversions-campaigns). |
 | `asa ad-groups update <id>` | at least one field | The campaign is resolved server-side and is never passed on update. |
 
 ## Ads

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapty",
   "description": "Adapty command line interface",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "author": "Adapty team <support@adapty.io>",
   "bin": {
     "adapty": "./bin/run.js"

--- a/skills/adapty-cli/references/asa-agent-playbook.md
+++ b/skills/adapty-cli/references/asa-agent-playbook.md
@@ -175,6 +175,18 @@ adapty asa keywords update KW_UUID [KW_UUID...] --bid 2.00 --yes
 adapty asa competitors summary --app-ids 1668337467,6503873027
 ```
 
+**"Create a Max Conversions campaign"** — two writes, always both: Apple keeps an MC campaign
+`NOT_RUNNING` (`AUTOMATED_KEYWORDS_REQUIRED_AD_GROUP_MISSING`) until it owns an automated ad group.
+Check `payment_model` in `asa orgs list` first — a `LOC` organization also needs the five `--invoice-*`
+flags on the campaign, or it stays `NOT_RUNNING` with `MISSING_BO_OR_INVOICING_FIELDS`:
+```sh
+adapty asa campaigns create --org ORG_UUID --name "Max Conv" --adam-id 123456 --country US --daily-budget 50 --bidding-strategy MAX_CONVERSIONS
+adapty asa ad-groups create --campaign CAMPAIGN_UUID --name "Automated Max Conv" --automated
+```
+Read `serving_status` / `serving_state_reasons` in the response: the command prints the fixing command
+for the reasons above. For an existing LOC campaign, `asa campaigns update <id> --invoice-*...` sets the
+Invoicing Options.
+
 ## What the failed sessions did wrong (do not repeat)
 
 - Looped `--page 1..4` to build an account total → burned the 5/min budget, hit 429s, gave up.

--- a/skills/adapty-cli/references/cli-commands.md
+++ b/skills/adapty-cli/references/cli-commands.md
@@ -169,7 +169,7 @@ every `asa` command answers `402 ads_manager_subscription_required`. Start with 
 | `asa campaigns create`               | `--org`, `--name`, `--adam-id`, `--country` (repeatable), `--daily-budget`; optional `--target-cpa`, `--bidding-strategy`; LOC orgs: all five `--invoice-*` flags. A `MAX_CONVERSIONS` campaign also needs `ad-groups create --automated` or it stays `NOT_RUNNING` (`AUTOMATED_KEYWORDS_REQUIRED_AD_GROUP_MISSING`) |
 | `asa campaigns update <campaign_id>` | at least one of `--name`, `--status`, `--country`, `--daily-budget`, `--budget`, `--target-cpa`, `--bidding-strategy`, or the five `--invoice-*` flags together (fixes `MISSING_BO_OR_INVOICING_FIELDS`) |
 | `asa ad-groups list` / `get <id>`    | metadata only, like campaigns; numbers come from `asa metrics`              |
-| `asa ad-groups create`               | `--campaign`, `--name`, `--default-bid`; Apple also needs `--pricing-model` (default CPC) and `--start-time` (default today). `--automated` = the automated group for Max Conversions: no `--start-time`, `--default-bid` optional |
+| `asa ad-groups create`               | `--campaign`, `--name`, `--default-bid`; Apple also needs `--pricing-model` (default CPC) and `--start-time` (default today). `--automated` = the automated group for Max Conversions: no `--start-time`, no `--status PAUSED`, `--default-bid` optional |
 | `asa ad-groups update <id>`          | at least one field; the campaign is resolved server-side, never passed      |
 | `asa keywords list`                  | metadata only; **filter by `--ad-group`** — the heaviest read, own budget (30/min, 2 concurrent, 60s cap) |
 | `asa keywords add`                   | `--ad-group` plus `--text` (repeatable) and/or `--from-file`; max 100 per call |

--- a/skills/adapty-cli/references/cli-commands.md
+++ b/skills/adapty-cli/references/cli-commands.md
@@ -163,13 +163,13 @@ every `asa` command answers `402 ads_manager_subscription_required`. Start with 
 | `asa whoami`                         | company, how access was granted, Apple connection state                     |
 | `asa connect`                        | prints the Apple authorization link and waits; `--no-wait` returns at once  |
 | `asa apps list`                      | (pagination only)                                                           |
-| `asa orgs list`                      | ASA organizations; their ID is the `--org` of `campaigns create`            |
+| `asa orgs list`                      | ASA organizations; their ID is the `--org` of `campaigns create`; `payment_model: LOC` means campaigns need the five `--invoice-*` flags |
 | `asa campaigns list`                 | metadata only, no metrics; filters below                                    |
 | `asa campaigns get <campaign_id>`    | positional UUID                                                             |
-| `asa campaigns create`               | `--org`, `--name`, `--adam-id`, `--country` (repeatable), `--daily-budget`; optional `--target-cpa`, `--bidding-strategy` |
-| `asa campaigns update <campaign_id>` | at least one of `--name`, `--status`, `--country`, `--daily-budget`, `--budget`, `--target-cpa`, `--bidding-strategy` |
+| `asa campaigns create`               | `--org`, `--name`, `--adam-id`, `--country` (repeatable), `--daily-budget`; optional `--target-cpa`, `--bidding-strategy`; LOC orgs: all five `--invoice-*` flags. A `MAX_CONVERSIONS` campaign also needs `ad-groups create --automated` or it stays `NOT_RUNNING` (`AUTOMATED_KEYWORDS_REQUIRED_AD_GROUP_MISSING`) |
+| `asa campaigns update <campaign_id>` | at least one of `--name`, `--status`, `--country`, `--daily-budget`, `--budget`, `--target-cpa`, `--bidding-strategy`, or the five `--invoice-*` flags together (fixes `MISSING_BO_OR_INVOICING_FIELDS`) |
 | `asa ad-groups list` / `get <id>`    | metadata only, like campaigns; numbers come from `asa metrics`              |
-| `asa ad-groups create`               | `--campaign`, `--name`, `--default-bid`; Apple also needs `--pricing-model` (default CPC) and `--start-time` (default today) |
+| `asa ad-groups create`               | `--campaign`, `--name`, `--default-bid`; Apple also needs `--pricing-model` (default CPC) and `--start-time` (default today). `--automated` = the automated group for Max Conversions: no `--start-time`, `--default-bid` optional |
 | `asa ad-groups update <id>`          | at least one field; the campaign is resolved server-side, never passed      |
 | `asa keywords list`                  | metadata only; **filter by `--ad-group`** — the heaviest read, own budget (30/min, 2 concurrent, 60s cap) |
 | `asa keywords add`                   | `--ad-group` plus `--text` (repeatable) and/or `--from-file`; max 100 per call |

--- a/src/commands/asa/ad-groups/create.ts
+++ b/src/commands/asa/ad-groups/create.ts
@@ -33,8 +33,7 @@ export default class AsaAdGroupsCreate extends Command {
     ...confirmFlags,
     ...idempotencyFlags,
     automated: Flags.boolean({
-      description:
-        'Create the automated ad group a Max Conversions campaign needs; implies automated keywords, takes no --start-time and makes --default-bid optional',
+      description: 'Create the automated ad group a Max Conversions campaign needs (no bid, no schedule, always ENABLED)',
       exclusive: ['automated-keywords'],
     }),
     'automated-keywords': Flags.boolean({allowNo: true, description: 'Let Apple add keywords automatically'}),
@@ -53,9 +52,11 @@ export default class AsaAdGroupsCreate extends Command {
     }
 
     if (flags.automated && flags['start-time'] !== undefined) {
-      this.error('--start-time cannot be combined with --automated: Apple rejects a schedule on an automated ad group.', {
-        exit: 2,
-      })
+      this.error('--start-time is not allowed with --automated: Apple schedules the automated ad group itself.', {exit: 2})
+    }
+
+    if (flags.automated && flags.status === 'PAUSED') {
+      this.error('An automated ad group must be ENABLED; pause the campaign instead.', {exit: 2})
     }
 
     const body = {

--- a/src/commands/asa/ad-groups/create.ts
+++ b/src/commands/asa/ad-groups/create.ts
@@ -18,11 +18,13 @@ import {isValidUuid} from '../../../lib/flags.js'
 import {printResponse} from '../../../lib/output.js'
 
 export default class AsaAdGroupsCreate extends Command {
-  static description = 'Create an ad group inside a campaign'
+  static description =
+    'Create an ad group inside a campaign; --automated creates the automated ad group a Max Conversions campaign needs to run'
   static enableJsonFlag = true
   static examples = [
     '<%= config.bin %> asa ad-groups create --campaign UUID --name "Brand terms" --default-bid 1.20',
     '<%= config.bin %> asa ad-groups create --campaign UUID --name "Brand terms" --default-bid 1.20 --start-time 2026-09-01 --pricing-model CPM',
+    '<%= config.bin %> asa ad-groups create --campaign UUID --name "Automated Max Conv" --automated',
   ]
   static flags = {
     ...currencyFlag,
@@ -30,10 +32,15 @@ export default class AsaAdGroupsCreate extends Command {
     ...pricingModelFlag,
     ...confirmFlags,
     ...idempotencyFlags,
+    automated: Flags.boolean({
+      description:
+        'Create the automated ad group a Max Conversions campaign needs; implies automated keywords, takes no --start-time and makes --default-bid optional',
+      exclusive: ['automated-keywords'],
+    }),
     'automated-keywords': Flags.boolean({allowNo: true, description: 'Let Apple add keywords automatically'}),
     campaign: Flags.string({description: 'Campaign ID (UUID)', required: true}),
     'cpa-goal': moneyFlag('CPA goal'),
-    'default-bid': moneyFlag('Default bid', {required: true}),
+    'default-bid': moneyFlag('Default bid; required unless --automated is set'),
     name: Flags.string({description: 'Ad group name', required: true}),
     status: Flags.string({description: 'Initial status', options: ['ENABLED', 'PAUSED']}),
   }
@@ -41,16 +48,26 @@ export default class AsaAdGroupsCreate extends Command {
   async run(): Promise<AsaAdGroupMutationDTO> {
     const {flags} = await this.parse(AsaAdGroupsCreate)
     if (!isValidUuid(flags.campaign)) this.error('Invalid campaign ID format.', {exit: 2})
+    if (!flags.automated && flags['default-bid'] === undefined) {
+      this.error('--default-bid is required unless --automated is set.', {exit: 2})
+    }
+
+    if (flags.automated && flags['start-time'] !== undefined) {
+      this.error('--start-time cannot be combined with --automated: Apple rejects a schedule on an automated ad group.', {
+        exit: 2,
+      })
+    }
 
     const body = {
-      automated_keywords_opt_in: flags['automated-keywords'],
+      automated_keywords_opt_in: flags.automated ? true : flags['automated-keywords'],
+      automated_keywords_required: flags.automated ? true : undefined,
       campaign_id: flags.campaign,
       cpa_goal: money(flags['cpa-goal'], flags.currency),
       default_bid_amount: money(flags['default-bid'], flags.currency),
       end_time: startOfDayUtc(flags['end-time']),
       name: flags.name,
       pricing_model: flags['pricing-model'],
-      start_time: startOfDayUtc(flags['start-time'] ?? todayUtc()),
+      start_time: flags.automated ? undefined : startOfDayUtc(flags['start-time'] ?? todayUtc()),
       status: flags.status,
     }
     await confirmMutation(

--- a/src/commands/asa/campaigns/create.ts
+++ b/src/commands/asa/campaigns/create.ts
@@ -4,20 +4,32 @@ import type {AsaCampaignMutationDTO} from '../../../lib/asa-schemas.js'
 
 import {asaWrite, createAsaClient, noteReplay} from '../../../lib/asa-client.js'
 import {confirmFlags, confirmMutation} from '../../../lib/asa-confirm.js'
-import {currencyFlag, idempotencyFlags, money, moneyFlag} from '../../../lib/asa-flags.js'
+import {
+  currencyFlag,
+  idempotencyFlags,
+  invoiceFlags,
+  locInvoiceDetails,
+  money,
+  moneyFlag,
+  reportServingState,
+} from '../../../lib/asa-flags.js'
 import {isValidUuid} from '../../../lib/flags.js'
 import {printResponse} from '../../../lib/output.js'
 
 export default class AsaCampaignsCreate extends Command {
-  static description = 'Create a campaign in Apple Search Ads'
+  static description =
+    'Create a campaign in Apple Search Ads. A Max Conversions campaign also needs an automated ad group (`asa ad-groups create --automated`); line-of-credit organizations must pass all five --invoice-* flags'
   static enableJsonFlag = true
   static examples = [
     '<%= config.bin %> asa campaigns create --org UUID --name "Winter push" --adam-id 123456 --country US --daily-budget 50',
+    '<%= config.bin %> asa campaigns create --org UUID --name "Max Conv" --adam-id 123456 --country US --daily-budget 50 --bidding-strategy MAX_CONVERSIONS',
+    '<%= config.bin %> asa campaigns create --org UUID --name "LOC push" --adam-id 123456 --country US --daily-budget 50 --invoice-advertiser "Acme Inc" --invoice-order-number PO-42 --invoice-contact-name "Jane Doe" --invoice-contact-email jane@acme.com --invoice-billing-email billing@acme.com',
   ]
   static flags = {
     ...currencyFlag,
     ...confirmFlags,
     ...idempotencyFlags,
+    ...invoiceFlags,
     'ad-channel-type': Flags.string({default: 'SEARCH', description: 'Ad channel type', options: ['DISPLAY', 'SEARCH']}),
     'adam-id': Flags.integer({description: 'App Store app ID (adam_id)', required: true}),
     'bidding-strategy': Flags.string({
@@ -52,6 +64,7 @@ export default class AsaCampaignsCreate extends Command {
       campaign_group_id: flags.org,
       countries_or_regions: flags.country,
       daily_budget_amount: money(flags['daily-budget'], flags.currency),
+      loc_invoice_details: locInvoiceDetails(flags, (msg) => this.error(msg, {exit: 2})),
       name: flags.name,
       status: flags.status,
       supply_sources: flags['supply-source'],
@@ -68,6 +81,7 @@ export default class AsaCampaignsCreate extends Command {
     noteReplay(replayed, this.log.bind(this))
     if (result.campaign && !replayed) this.log('Campaign created!')
     printResponse(result as unknown as Record<string, unknown>, this.log.bind(this))
+    reportServingState(result.campaign, this.log.bind(this))
 
     return result
   }

--- a/src/commands/asa/campaigns/create.ts
+++ b/src/commands/asa/campaigns/create.ts
@@ -48,12 +48,19 @@ export default class AsaCampaignsCreate extends Command {
       description: 'Supply source, repeatable',
       multiple: true,
     }),
-    'target-cpa': moneyFlag('Target CPA'),
+    'target-cpa': moneyFlag('Target CPA; must be lower than --daily-budget'),
   }
 
   async run(): Promise<AsaCampaignMutationDTO> {
     const {flags} = await this.parse(AsaCampaignsCreate)
     if (!isValidUuid(flags.org)) this.error('Invalid org ID format.', {exit: 2})
+
+    let invoice
+    try {
+      invoice = locInvoiceDetails(flags)
+    } catch (error) {
+      this.error((error as Error).message, {exit: 2})
+    }
 
     const body = {
       ad_channel_type: flags['ad-channel-type'],
@@ -64,7 +71,7 @@ export default class AsaCampaignsCreate extends Command {
       campaign_group_id: flags.org,
       countries_or_regions: flags.country,
       daily_budget_amount: money(flags['daily-budget'], flags.currency),
-      loc_invoice_details: locInvoiceDetails(flags, (msg) => this.error(msg, {exit: 2})),
+      loc_invoice_details: invoice,
       name: flags.name,
       status: flags.status,
       supply_sources: flags['supply-source'],
@@ -81,7 +88,7 @@ export default class AsaCampaignsCreate extends Command {
     noteReplay(replayed, this.log.bind(this))
     if (result.campaign && !replayed) this.log('Campaign created!')
     printResponse(result as unknown as Record<string, unknown>, this.log.bind(this))
-    reportServingState(result.campaign, this.log.bind(this))
+    reportServingState(result.campaign, this.warn.bind(this))
 
     return result
   }

--- a/src/commands/asa/campaigns/update.ts
+++ b/src/commands/asa/campaigns/update.ts
@@ -4,7 +4,15 @@ import type {AsaCampaignMutationDTO} from '../../../lib/asa-schemas.js'
 
 import {asaWrite, createAsaClient, noteReplay} from '../../../lib/asa-client.js'
 import {confirmFlags, confirmMutation} from '../../../lib/asa-confirm.js'
-import {currencyFlag, idempotencyFlags, money, moneyFlag} from '../../../lib/asa-flags.js'
+import {
+  currencyFlag,
+  idempotencyFlags,
+  invoiceFlags,
+  locInvoiceDetails,
+  money,
+  moneyFlag,
+  reportServingState,
+} from '../../../lib/asa-flags.js'
 import {isValidUuid} from '../../../lib/flags.js'
 import {printResponse} from '../../../lib/output.js'
 
@@ -12,16 +20,19 @@ export default class AsaCampaignsUpdate extends Command {
   static args = {
     campaign_id: Args.string({description: 'Campaign ID (UUID)', required: true}),
   }
-  static description = 'Change a campaign: budgets, countries, status or schedule'
+  static description =
+    'Change a campaign: budgets, countries, status, schedule or Invoicing Options (all five --invoice-* flags together; they replace the stored set)'
   static enableJsonFlag = true
   static examples = [
     '<%= config.bin %> asa campaigns update UUID --status PAUSED',
     '<%= config.bin %> asa campaigns update UUID --daily-budget 80',
+    '<%= config.bin %> asa campaigns update UUID --invoice-advertiser "Acme Inc" --invoice-order-number PO-42 --invoice-contact-name "Jane Doe" --invoice-contact-email jane@acme.com --invoice-billing-email billing@acme.com',
   ]
   static flags = {
     ...currencyFlag,
     ...confirmFlags,
     ...idempotencyFlags,
+    ...invoiceFlags,
     'bidding-strategy': Flags.string({
       description: 'Bidding strategy',
       options: ['MANUAL_CPT', 'MAX_CONVERSIONS'],
@@ -46,9 +57,14 @@ export default class AsaCampaignsUpdate extends Command {
     if (flags.budget !== undefined) body.budget_amount = money(flags.budget, flags.currency)
     if (flags['target-cpa'] !== undefined) body.target_cpa = money(flags['target-cpa'], flags.currency)
     if (flags['bidding-strategy'] !== undefined) body.bidding_strategy = flags['bidding-strategy']
+    const invoice = locInvoiceDetails(flags, (msg) => this.error(msg, {exit: 2}))
+    if (invoice !== undefined) body.loc_invoice_details = invoice
 
     if (Object.keys(body).length === 0) {
-      this.error('Nothing to change. Pass at least one field, e.g. --status PAUSED.', {exit: 2})
+      this.error(
+        'Nothing to change. Pass at least one field, e.g. --status PAUSED, or the five --invoice-* flags for a line-of-credit organization.',
+        {exit: 2},
+      )
     }
 
     await confirmMutation(
@@ -66,6 +82,7 @@ export default class AsaCampaignsUpdate extends Command {
     noteReplay(replayed, this.log.bind(this))
     if (result.campaign && !replayed) this.log('Campaign updated!')
     printResponse(result as unknown as Record<string, unknown>, this.log.bind(this))
+    reportServingState(result.campaign, this.log.bind(this))
 
     return result
   }

--- a/src/commands/asa/campaigns/update.ts
+++ b/src/commands/asa/campaigns/update.ts
@@ -57,8 +57,12 @@ export default class AsaCampaignsUpdate extends Command {
     if (flags.budget !== undefined) body.budget_amount = money(flags.budget, flags.currency)
     if (flags['target-cpa'] !== undefined) body.target_cpa = money(flags['target-cpa'], flags.currency)
     if (flags['bidding-strategy'] !== undefined) body.bidding_strategy = flags['bidding-strategy']
-    const invoice = locInvoiceDetails(flags, (msg) => this.error(msg, {exit: 2}))
-    if (invoice !== undefined) body.loc_invoice_details = invoice
+    try {
+      const details = locInvoiceDetails(flags)
+      if (details) body.loc_invoice_details = details
+    } catch (error) {
+      this.error((error as Error).message, {exit: 2})
+    }
 
     if (Object.keys(body).length === 0) {
       this.error(
@@ -82,7 +86,7 @@ export default class AsaCampaignsUpdate extends Command {
     noteReplay(replayed, this.log.bind(this))
     if (result.campaign && !replayed) this.log('Campaign updated!')
     printResponse(result as unknown as Record<string, unknown>, this.log.bind(this))
-    reportServingState(result.campaign, this.log.bind(this))
+    reportServingState(result.campaign, this.warn.bind(this))
 
     return result
   }

--- a/src/lib/asa-flags.ts
+++ b/src/lib/asa-flags.ts
@@ -1,7 +1,7 @@
 import {Flags} from '@oclif/core'
 
 import type {QueryParams} from './api-client.js'
-import type {AsaLocInvoiceDetails, AsaMoney, AsaMutationError, AsaServingStatus} from './asa-schemas.js'
+import type {AsaLocInvoiceDetails, AsaMoney, AsaMutationError} from './asa-schemas.js'
 
 import {describeListedError} from './errors.js'
 import {isValidUuid} from './flags.js'
@@ -170,30 +170,28 @@ const INVOICE_FIELDS = {
 
 type InvoiceFlagName = keyof typeof INVOICE_FIELDS
 
-const INVOICE_SUFFIX =
-  'Invoicing Options, required for line-of-credit (LOC) organizations — see `payment_model` in `asa orgs list`'
+const INVOICE_PREFIX = 'Invoicing Options (line-of-credit orgs, see payment_model in asa orgs list)'
 
 function invoiceFlag(what: string) {
-  return Flags.string({description: `${what} for ${INVOICE_SUFFIX}`})
+  return Flags.string({description: `${INVOICE_PREFIX}: ${what}`})
 }
 
 export const invoiceFlags = {
-  'invoice-advertiser': invoiceFlag('Advertiser name'),
-  'invoice-billing-email': invoiceFlag('Billing contact email'),
-  'invoice-contact-email': invoiceFlag('Buyer contact email'),
-  'invoice-contact-name': invoiceFlag('Buyer contact name'),
-  'invoice-order-number': invoiceFlag('Order number'),
+  'invoice-advertiser': invoiceFlag('advertiser name'),
+  'invoice-billing-email': invoiceFlag('billing contact email'),
+  'invoice-contact-email': invoiceFlag('buyer contact email'),
+  'invoice-contact-name': invoiceFlag('buyer contact name'),
+  'invoice-order-number': invoiceFlag('order number'),
 }
 
 export function locInvoiceDetails(
   flags: Partial<Record<InvoiceFlagName, string>>,
-  fail: (msg: string) => never,
 ): Record<keyof AsaLocInvoiceDetails, string> | undefined {
   const names = Object.keys(INVOICE_FIELDS) as InvoiceFlagName[]
   const missing = names.filter((name) => flags[name] === undefined)
   if (missing.length === names.length) return undefined
   if (missing.length > 0) {
-    fail(`Invoicing Options must be passed together; missing: ${missing.map((name) => `--${name}`).join(', ')}.`)
+    throw new Error(`Invoicing Options need all five flags; missing: ${missing.map((name) => `--${name}`).join(', ')}`)
   }
 
   return Object.fromEntries(names.map((name) => [INVOICE_FIELDS[name], flags[name]])) as Record<
@@ -210,15 +208,19 @@ const SERVING_HINTS: Record<string, (campaignId: string) => string> = {
 }
 
 export function reportServingState(
-  campaign: null | {internal_id: string; serving_state_reasons?: null | string[]; serving_status?: AsaServingStatus | null},
-  log: (msg: string) => void,
+  campaign: null | {internal_id: string; serving_state_reasons?: null | string[]; serving_status?: null | string},
+  warn: (msg: string) => void,
 ): void {
   if (campaign?.serving_status !== 'NOT_RUNNING' || !campaign.serving_state_reasons?.length) return
-  log(`Campaign is not running: ${campaign.serving_state_reasons.join(', ')}`)
-  for (const reason of campaign.serving_state_reasons) {
+  const reasons = campaign.serving_state_reasons
+  if (reasons.length === 1 && reasons[0] === 'PAUSED_BY_USER') return
+  for (const reason of reasons) {
     const hint = SERVING_HINTS[reason]
-    if (hint) log(hint(campaign.internal_id))
+    if (hint) warn(hint(campaign.internal_id))
   }
+
+  const other = reasons.filter((reason) => !SERVING_HINTS[reason])
+  if (other.length > 0) warn(`Not serving: ${other.join(', ')}`)
 }
 
 interface BulkOutcome {

--- a/src/lib/asa-flags.ts
+++ b/src/lib/asa-flags.ts
@@ -1,7 +1,7 @@
 import {Flags} from '@oclif/core'
 
 import type {QueryParams} from './api-client.js'
-import type {AsaMoney, AsaMutationError} from './asa-schemas.js'
+import type {AsaLocInvoiceDetails, AsaMoney, AsaMutationError, AsaServingStatus} from './asa-schemas.js'
 
 import {describeListedError} from './errors.js'
 import {isValidUuid} from './flags.js'
@@ -158,6 +158,67 @@ export const idempotencyFlags = {
 
 export function money(amount: string | undefined, currency: string): AsaMoney | undefined {
   return amount === undefined ? undefined : {amount, currency}
+}
+
+const INVOICE_FIELDS = {
+  'invoice-advertiser': 'client_name',
+  'invoice-billing-email': 'billing_contact_email',
+  'invoice-contact-email': 'buyer_email',
+  'invoice-contact-name': 'buyer_name',
+  'invoice-order-number': 'order_number',
+} as const
+
+type InvoiceFlagName = keyof typeof INVOICE_FIELDS
+
+const INVOICE_SUFFIX =
+  'Invoicing Options, required for line-of-credit (LOC) organizations — see `payment_model` in `asa orgs list`'
+
+function invoiceFlag(what: string) {
+  return Flags.string({description: `${what} for ${INVOICE_SUFFIX}`})
+}
+
+export const invoiceFlags = {
+  'invoice-advertiser': invoiceFlag('Advertiser name'),
+  'invoice-billing-email': invoiceFlag('Billing contact email'),
+  'invoice-contact-email': invoiceFlag('Buyer contact email'),
+  'invoice-contact-name': invoiceFlag('Buyer contact name'),
+  'invoice-order-number': invoiceFlag('Order number'),
+}
+
+export function locInvoiceDetails(
+  flags: Partial<Record<InvoiceFlagName, string>>,
+  fail: (msg: string) => never,
+): Record<keyof AsaLocInvoiceDetails, string> | undefined {
+  const names = Object.keys(INVOICE_FIELDS) as InvoiceFlagName[]
+  const missing = names.filter((name) => flags[name] === undefined)
+  if (missing.length === names.length) return undefined
+  if (missing.length > 0) {
+    fail(`Invoicing Options must be passed together; missing: ${missing.map((name) => `--${name}`).join(', ')}.`)
+  }
+
+  return Object.fromEntries(names.map((name) => [INVOICE_FIELDS[name], flags[name]])) as Record<
+    keyof AsaLocInvoiceDetails,
+    string
+  >
+}
+
+const SERVING_HINTS: Record<string, (campaignId: string) => string> = {
+  AUTOMATED_KEYWORDS_REQUIRED_AD_GROUP_MISSING: (campaignId) =>
+    `Max Conversions campaign needs an automated ad group: adapty asa ad-groups create --campaign ${campaignId} --name "Automated Max Conv" --automated`,
+  MISSING_BO_OR_INVOICING_FIELDS: (campaignId) =>
+    `This organization bills by line of credit — add Invoicing Options: adapty asa campaigns update ${campaignId} --invoice-advertiser ... --invoice-order-number ... --invoice-contact-name ... --invoice-contact-email ... --invoice-billing-email ...`,
+}
+
+export function reportServingState(
+  campaign: null | {internal_id: string; serving_state_reasons?: null | string[]; serving_status?: AsaServingStatus | null},
+  log: (msg: string) => void,
+): void {
+  if (campaign?.serving_status !== 'NOT_RUNNING' || !campaign.serving_state_reasons?.length) return
+  log(`Campaign is not running: ${campaign.serving_state_reasons.join(', ')}`)
+  for (const reason of campaign.serving_state_reasons) {
+    const hint = SERVING_HINTS[reason]
+    if (hint) log(hint(campaign.internal_id))
+  }
 }
 
 interface BulkOutcome {

--- a/src/lib/asa-schemas.ts
+++ b/src/lib/asa-schemas.ts
@@ -60,6 +60,18 @@ export interface AsaAppDTO {
   name: string
 }
 
+export type AsaPaymentModel = 'LOC' | 'PAYG'
+
+export type AsaServingStatus = 'NOT_RUNNING' | 'RUNNING'
+
+export interface AsaLocInvoiceDetails {
+  billing_contact_email: null | string
+  buyer_email: null | string
+  buyer_name: null | string
+  client_name: null | string
+  order_number: null | string
+}
+
 export interface AsaCampaignGroupDTO {
   currency: string
   internal_id: string
@@ -67,6 +79,7 @@ export interface AsaCampaignGroupDTO {
   org_id: number
   org_name: string
   parent_org_id: number
+  payment_model: AsaPaymentModel | null
   time_zone: string
 }
 
@@ -83,8 +96,12 @@ export interface AsaCampaignDTO {
   daily_budget_amount: AsaMoney | null
   end_time: null | string
   internal_id: string
+  loc_invoice_details: AsaLocInvoiceDetails | null
   name: string
   org_id: number
+  payment_model: AsaPaymentModel | null
+  serving_state_reasons: null | string[]
+  serving_status: AsaServingStatus | null
   start_time: null | string
   status: AsaStatus
   supply_sources: string[]
@@ -95,6 +112,7 @@ export interface AsaAdGroupDTO {
   ad_group_id: number
   app_id: string
   automated_keywords_opt_in: boolean | null
+  automated_keywords_required: boolean | null
   bidding_strategy: null | string
   campaign_group_id: string
   campaign_id: string
@@ -105,6 +123,8 @@ export interface AsaAdGroupDTO {
   name: string
   payment_model: null | string
   pricing_model: null | string
+  serving_state_reasons: null | string[]
+  serving_status: AsaServingStatus | null
   start_time: null | string
   status: AsaStatus | null
   target_cpa: AsaMoney | null
@@ -290,7 +310,11 @@ export interface AsaCampaignMutationEntity {
   campaign_group_id: string
   campaign_id: number
   internal_id: string
+  loc_invoice_details: AsaLocInvoiceDetails | null
   name: string
+  payment_model: AsaPaymentModel | null
+  serving_state_reasons: null | string[]
+  serving_status: AsaServingStatus | null
   status: AsaStatus
 }
 

--- a/src/lib/asa-schemas.ts
+++ b/src/lib/asa-schemas.ts
@@ -60,10 +60,6 @@ export interface AsaAppDTO {
   name: string
 }
 
-export type AsaPaymentModel = 'LOC' | 'PAYG'
-
-export type AsaServingStatus = 'NOT_RUNNING' | 'RUNNING'
-
 export interface AsaLocInvoiceDetails {
   billing_contact_email: null | string
   buyer_email: null | string
@@ -79,7 +75,7 @@ export interface AsaCampaignGroupDTO {
   org_id: number
   org_name: string
   parent_org_id: number
-  payment_model: AsaPaymentModel | null
+  payment_model: null | string
   time_zone: string
 }
 
@@ -99,9 +95,9 @@ export interface AsaCampaignDTO {
   loc_invoice_details: AsaLocInvoiceDetails | null
   name: string
   org_id: number
-  payment_model: AsaPaymentModel | null
+  payment_model: null | string
   serving_state_reasons: null | string[]
-  serving_status: AsaServingStatus | null
+  serving_status: null | string
   start_time: null | string
   status: AsaStatus
   supply_sources: string[]
@@ -124,7 +120,7 @@ export interface AsaAdGroupDTO {
   payment_model: null | string
   pricing_model: null | string
   serving_state_reasons: null | string[]
-  serving_status: AsaServingStatus | null
+  serving_status: null | string
   start_time: null | string
   status: AsaStatus | null
   target_cpa: AsaMoney | null
@@ -312,9 +308,9 @@ export interface AsaCampaignMutationEntity {
   internal_id: string
   loc_invoice_details: AsaLocInvoiceDetails | null
   name: string
-  payment_model: AsaPaymentModel | null
+  payment_model: null | string
   serving_state_reasons: null | string[]
-  serving_status: AsaServingStatus | null
+  serving_status: null | string
   status: AsaStatus
 }
 

--- a/test/commands/asa-writes.test.ts
+++ b/test/commands/asa-writes.test.ts
@@ -20,6 +20,19 @@ const AD_GROUP_OK = {ad_group: {internal_id: TEST_RESOURCE_ID, name: 'Brand term
 const AD_OK = {ad: {internal_id: TEST_RESOURCE_ID, name: 'Summer ad'}, errors: []}
 const KEYWORDS_OK = {errors: [], is_validation_failure: false, keywords: [{internal_id: TEST_RESOURCE_ID, text: 'running shoes'}]}
 const NEGATIVES_OK = {errors: [], is_validation_failure: false, negative_keywords: [{internal_id: TEST_RESOURCE_ID, text: 'free'}]}
+const INVOICE_FLAGS =
+  '--invoice-advertiser "Acme Inc" --invoice-order-number PO-42 --invoice-contact-name "Jane Doe" --invoice-contact-email jane@acme.com --invoice-billing-email billing@acme.com'
+const INVOICE_BODY = {
+  billing_contact_email: 'billing@acme.com',
+  buyer_email: 'jane@acme.com',
+  buyer_name: 'Jane Doe',
+  client_name: 'Acme Inc',
+  order_number: 'PO-42',
+}
+const notRunning = (reasons: string[]) => ({
+  campaign: {...CAMPAIGN_OK.campaign, serving_state_reasons: reasons, serving_status: 'NOT_RUNNING'},
+  errors: [],
+})
 
 describe('asa writes', () => {
   let fetchStub: sinon.SinonStub
@@ -152,6 +165,78 @@ describe('asa writes', () => {
     )
     expect(error?.message).to.contain('YYYY-MM-DD')
     expect(fetchStub.callCount).to.equal(0)
+  })
+
+  it('ad-groups create --automated sends the automated group without a schedule or a bid', async () => {
+    fetchStub = mockFetch([AD_GROUP_OK])
+    await runCommand(`asa ad-groups create --yes --campaign ${TEST_RESOURCE_ID} --name "Automated Max Conv" --automated`)
+    const body = JSON.parse(fetchStub.getCall(0).args[1].body as string)
+    expect(body).to.deep.equal({
+      automated_keywords_opt_in: true,
+      automated_keywords_required: true,
+      campaign_id: TEST_RESOURCE_ID,
+      name: 'Automated Max Conv',
+      pricing_model: 'CPC',
+    })
+  })
+
+  it('ad-groups create demands --default-bid unless --automated and refuses a schedule on an automated group', async () => {
+    fetchStub = mockFetch([AD_GROUP_OK])
+    const noBid = await runCommand(`asa ad-groups create --yes --campaign ${TEST_RESOURCE_ID} --name AG`)
+    expect(noBid.error?.message).to.contain('--default-bid is required unless --automated')
+    const scheduled = await runCommand(
+      `asa ad-groups create --yes --campaign ${TEST_RESOURCE_ID} --name AG --automated --start-time 2026-09-01`,
+    )
+    expect(scheduled.error?.message).to.contain('--start-time')
+    expect(fetchStub.callCount).to.equal(0)
+  })
+
+  it('campaigns carry Invoicing Options as one snake_case object, only when asked', async () => {
+    fetchStub = mockFetch([CAMPAIGN_OK, CAMPAIGN_OK, CAMPAIGN_OK])
+    await runCommand(
+      `asa campaigns create --yes --org ${TEST_APP_ID} --name x --adam-id 1 --country US --daily-budget 50 ${INVOICE_FLAGS}`,
+    )
+    const created = JSON.parse(fetchStub.getCall(0).args[1].body as string)
+    expect(created.loc_invoice_details).to.deep.equal(INVOICE_BODY)
+
+    await runCommand(`asa campaigns create --yes --org ${TEST_APP_ID} --name x --adam-id 1 --country US --daily-budget 50`)
+    const plain = JSON.parse(fetchStub.getCall(1).args[1].body as string)
+    expect(plain).to.not.have.property('loc_invoice_details')
+
+    await runCommand(`asa campaigns update --yes ${TEST_RESOURCE_ID} ${INVOICE_FLAGS}`)
+    const updated = JSON.parse(fetchStub.getCall(2).args[1].body as string)
+    expect(updated).to.deep.equal({loc_invoice_details: INVOICE_BODY})
+  })
+
+  it('campaigns refuse a partial set of Invoicing Options before the network', async () => {
+    fetchStub = mockFetch([CAMPAIGN_OK])
+    const {error} = await runCommand(
+      `asa campaigns create --yes --org ${TEST_APP_ID} --name x --adam-id 1 --country US --daily-budget 50 --invoice-advertiser Acme --invoice-order-number PO-42 --invoice-contact-name Jane`,
+    )
+    expect(error?.message).to.contain('--invoice-contact-email')
+    expect(error?.message).to.contain('--invoice-billing-email')
+    expect(error?.message).to.not.contain('--invoice-advertiser')
+    expect(fetchStub.callCount).to.equal(0)
+  })
+
+  it('campaigns explain why a campaign is not running and how to fix it', async () => {
+    fetchStub = mockFetch([
+      notRunning(['AUTOMATED_KEYWORDS_REQUIRED_AD_GROUP_MISSING']),
+      notRunning(['MISSING_BO_OR_INVOICING_FIELDS', 'SOMETHING_ELSE']),
+      notRunning(['AUTOMATED_KEYWORDS_REQUIRED_AD_GROUP_MISSING']),
+    ])
+    const created = await runCommand(
+      `asa campaigns create --yes --org ${TEST_APP_ID} --name x --adam-id 1 --country US --daily-budget 50 --bidding-strategy MAX_CONVERSIONS`,
+    )
+    expect(created.stdout).to.contain('not running: AUTOMATED_KEYWORDS_REQUIRED_AD_GROUP_MISSING')
+    expect(created.stdout).to.contain(`ad-groups create --campaign ${TEST_RESOURCE_ID} --name "Automated Max Conv" --automated`)
+
+    const updated = await runCommand(`asa campaigns update --yes ${TEST_RESOURCE_ID} --status ENABLED`)
+    expect(updated.stdout).to.contain('not running: MISSING_BO_OR_INVOICING_FIELDS, SOMETHING_ELSE')
+    expect(updated.stdout).to.contain(`campaigns update ${TEST_RESOURCE_ID} --invoice-advertiser`)
+
+    const asJson = await runCommand(`asa campaigns update --yes --json ${TEST_RESOURCE_ID} --status ENABLED`)
+    expect(JSON.parse(asJson.stdout).campaign.serving_status).to.equal('NOT_RUNNING')
   })
 
   it('keywords add turns repeated --text into one batch', async () => {

--- a/test/commands/asa-writes.test.ts
+++ b/test/commands/asa-writes.test.ts
@@ -29,7 +29,7 @@ const INVOICE_BODY = {
   client_name: 'Acme Inc',
   order_number: 'PO-42',
 }
-const unwrap = (stderr: string) => stderr.replaceAll(/\s*›\s*/g, ' ').replaceAll(/\s+/g, ' ')
+const unwrap = (stderr: string) => stderr.replaceAll(/\s*[›»]\s*/g, ' ').replaceAll(/\s+/g, ' ')
 const notRunning = (reasons: string[]) => ({
   campaign: {...CAMPAIGN_OK.campaign, serving_state_reasons: reasons, serving_status: 'NOT_RUNNING'},
   errors: [],

--- a/test/commands/asa-writes.test.ts
+++ b/test/commands/asa-writes.test.ts
@@ -29,6 +29,7 @@ const INVOICE_BODY = {
   client_name: 'Acme Inc',
   order_number: 'PO-42',
 }
+const unwrap = (stderr: string) => stderr.replaceAll(/\s*›\s*/g, ' ').replaceAll(/\s+/g, ' ')
 const notRunning = (reasons: string[]) => ({
   campaign: {...CAMPAIGN_OK.campaign, serving_state_reasons: reasons, serving_status: 'NOT_RUNNING'},
   errors: [],
@@ -188,6 +189,10 @@ describe('asa writes', () => {
       `asa ad-groups create --yes --campaign ${TEST_RESOURCE_ID} --name AG --automated --start-time 2026-09-01`,
     )
     expect(scheduled.error?.message).to.contain('--start-time')
+    const paused = await runCommand(
+      `asa ad-groups create --yes --campaign ${TEST_RESOURCE_ID} --name AG --automated --status PAUSED`,
+    )
+    expect(paused.error?.message).to.contain('must be ENABLED')
     expect(fetchStub.callCount).to.equal(0)
   })
 
@@ -223,20 +228,28 @@ describe('asa writes', () => {
     fetchStub = mockFetch([
       notRunning(['AUTOMATED_KEYWORDS_REQUIRED_AD_GROUP_MISSING']),
       notRunning(['MISSING_BO_OR_INVOICING_FIELDS', 'SOMETHING_ELSE']),
+      notRunning(['PAUSED_BY_USER']),
       notRunning(['AUTOMATED_KEYWORDS_REQUIRED_AD_GROUP_MISSING']),
     ])
     const created = await runCommand(
       `asa campaigns create --yes --org ${TEST_APP_ID} --name x --adam-id 1 --country US --daily-budget 50 --bidding-strategy MAX_CONVERSIONS`,
     )
-    expect(created.stdout).to.contain('not running: AUTOMATED_KEYWORDS_REQUIRED_AD_GROUP_MISSING')
-    expect(created.stdout).to.contain(`ad-groups create --campaign ${TEST_RESOURCE_ID} --name "Automated Max Conv" --automated`)
+    expect(unwrap(created.stderr)).to.contain(
+      `ad-groups create --campaign ${TEST_RESOURCE_ID} --name "Automated Max Conv" --automated`,
+    )
+    expect(created.stderr).to.not.contain('Not serving')
 
     const updated = await runCommand(`asa campaigns update --yes ${TEST_RESOURCE_ID} --status ENABLED`)
-    expect(updated.stdout).to.contain('not running: MISSING_BO_OR_INVOICING_FIELDS, SOMETHING_ELSE')
-    expect(updated.stdout).to.contain(`campaigns update ${TEST_RESOURCE_ID} --invoice-advertiser`)
+    expect(unwrap(updated.stderr)).to.contain(`campaigns update ${TEST_RESOURCE_ID} --invoice-advertiser`)
+    expect(unwrap(updated.stderr)).to.contain('Not serving: SOMETHING_ELSE')
+    expect(updated.stderr).to.not.contain('Not serving: MISSING_BO')
+
+    const paused = await runCommand(`asa campaigns update --yes ${TEST_RESOURCE_ID} --status PAUSED`)
+    expect(paused.stderr).to.not.contain('Not serving')
 
     const asJson = await runCommand(`asa campaigns update --yes --json ${TEST_RESOURCE_ID} --status ENABLED`)
     expect(JSON.parse(asJson.stdout).campaign.serving_status).to.equal('NOT_RUNNING')
+    expect(asJson.stderr).to.not.contain('--automated')
   })
 
   it('keywords add turns repeated --text into one batch', async () => {


### PR DESCRIPTION
## Why

- **ASA-767.** Max Conversions campaigns created through the CLI stayed `NOT_RUNNING` with `AUTOMATED_KEYWORDS_REQUIRED_AD_GROUP_MISSING`: Apple requires an automated ad group (`automatedKeywordsRequired=true`, no `start_time`), and the CLI could neither send that field nor omit the default start time.
- **ASA-768.** Line-of-credit organizations (`payment_model: LOC`) must fill Invoicing Options on every campaign, otherwise Apple parks it with `MISSING_BO_OR_INVOICING_FIELDS`. The CLI had no way to pass `loc_invoice_details`.
- The CLI never surfaced `serving_status` / `serving_state_reasons`, so users only saw "not spending".

Backend contract: `feature/ASA-767-cli-mc-loc` in asa-analytics (not deployed yet).

## What

- `asa ad-groups create --automated` — sends `automated_keywords_required: true`, `automated_keywords_opt_in: true`, no `start_time`, no `default_bid_amount` unless `--default-bid` is given. `--default-bid` is now required only without `--automated`; `--automated --start-time` exits 2 before the network.
- `asa campaigns create|update` — five Invoicing Options flags (`--invoice-advertiser`, `--invoice-order-number`, `--invoice-contact-name`, `--invoice-contact-email`, `--invoice-billing-email`) → `loc_invoice_details`. All five or none; a partial set exits 2 before the network.
- After a campaign mutation, `NOT_RUNNING` + `serving_state_reasons` are printed with the fixing command for the two reasons above (stdout only, `--json` stays a clean result).
- Schemas: `serving_status`, `serving_state_reasons`, `payment_model`, `loc_invoice_details`, `automated_keywords_required` on the matching DTOs.
- Docs (`docs/agent/asa-management.md`, skill references, README): Max Conversions and Line of credit sections, `payment_model` on `asa orgs list`.

## Checks

- `pnpm build`, `eslint src test` — clean
- `mocha` — 174 passing (5 new tests in `asa-writes.test.ts`)
- `node scripts/check-agent-docs.mjs` — docs match the manifest
