### PR TITLE
docs: metrics page cap lowered to 5000 rows

### DIFF
--- a/docs/agent/asa-metrics.md
+++ b/docs/agent/asa-metrics.md
@@ -47,7 +47,7 @@ over consecutive 28-day windows to cover a long period: that is the exact burst 
 gets a token throttled, and the daily points add nothing a weekly series doesn't show at that
 time scale.
 
-Besides the window caps, `metrics` caps every page at 20 000 breakdown rows — rows being
+Besides the window caps, `metrics` caps every page at 5 000 breakdown rows — rows being
 entities × countries × periods from `--group-by`. A page over the cap is refused with a 422
 `cli_response_too_large`; the fix is coarsening the grouping (week instead of day), narrowing
 the date window, or reducing `--page-size`. When `day` is in `--group-by` the refusal names
@@ -133,7 +133,7 @@ Three 429 codes, not one:
 - `cli_cooldown_active` — stop entirely; tell the user when to retry.
 
 One refusal is a 422, not a 429: `cli_response_too_large` — a `metrics` page would exceed
-20 000 breakdown rows (see [Date window caps](#date-window-caps)). It carries no
+5 000 breakdown rows (see [Date window caps](#date-window-caps)). It carries no
 `Retry-After` and doesn't count toward the cool-down; retrying is pointless — change the
 request instead (coarsen the grouping, narrow the window, or reduce `--page-size`).
 

--- a/src/commands/asa/metrics/index.ts
+++ b/src/commands/asa/metrics/index.ts
@@ -12,7 +12,7 @@ One row per entity, already aggregated server-side and sorted by --order-by, so 
 call with --order-by and --page-size N — never sum pages yourself. Account-level totals are one call to
 asa metrics overview instead. The date window is capped by the finest --group-by period: 28 days when
 day is grouped, 90 with no period grouping, 180 by week, 365 by month and coarser — widen the window by
-coarsening the grouping, not by splitting into more calls. Each page is also capped at 20000 breakdown
+coarsening the grouping, not by splitting into more calls. Each page is also capped at 5000 breakdown
 rows (entities × countries × periods); over it the call fails with 422 cli_response_too_large — coarsen
 the grouping, narrow the window, or reduce page[size]. Budget: 5 metrics calls per minute, at most
 2 per 10 seconds, one at a time.`


### PR DESCRIPTION
The backend lowers `MAX_BREAKDOWN_ROWS_PER_PAGE` from 20 000 to 5 000 after a paginated day-grain export starved the server event loop and got pods restarted by liveness. This updates the number in the `asa metrics` help text and the agent docs so they match.

No behaviour change: the client already takes `page[size]` from the 422 message, and the 5 calls/minute budget in the text already matches the new backend limit.