### PR TITLE
Make FlowDTO.status and PlacementSummaryDTO.is_active optional

### DIFF
--- a/src/lib/api-schemas.ts
+++ b/src/lib/api-schemas.ts
@@ -110,7 +110,8 @@ export type FlowStatus = string;
 export type FlowDTO = {
     id: string;
     name: string;
-    status: FlowStatus;
+    /** Optional: the flows-update (rename) response leaves status out. Read it from flows get. */
+    status?: FlowStatus;
     updated_at: string;
 };
 
@@ -200,8 +201,11 @@ export type PlacementAudienceEntryDTO = PlacementFlowAudienceEntryDTO | Placemen
 export type PlacementSummaryDTO = {
     developer_id: string;
     id: string;
-    /** Placement activation state: true = Live, false = Inactive. */
-    is_active: boolean;
+    /**
+     * Placement activation state: true = Live, false = Inactive.
+     * Optional — the paywall placements list leaves it out.
+     */
+    is_active?: boolean;
     title: string;
 };
 


### PR DESCRIPTION
Type-only change to match a Developer API hotfix. No runtime behavior change — the CLI renders whatever the API returns via `printResponse`, which skips absent fields.

## What

In `src/lib/api-schemas.ts`:
- `FlowDTO.status` → optional. `flows update` no longer returns it; get/list/create/publish still do.
- `PlacementSummaryDTO.is_active` → optional. The paywall placements endpoint omits it; placements list/get still return it.

The parallel `FlowConfigDTO.status` and `PlacementDetailDTO.is_active` stay required, since those responses still carry the fields.

## Verify

`pnpm build && pnpm test && pnpm lint && pnpm run check:agent-docs` — all green (203 tests passing).